### PR TITLE
Print trace of commands on ENTRYPOINT_DEBUG being set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1209,6 +1209,10 @@ function print_loaded_drv_ver_str() {
 }
 
 ############################## Exec start #####################################
+if ${ENTRYPOINT_DEBUG}; then
+    set -x
+fi
+
 [[ -f "/tmp/entrypoint_done" ]] && echo "Entrypoint already executed, restart container" && exit 0
 
 timestamp_print "NVIDIA driver container exec start"


### PR DESCRIPTION
This PR adds command traces when the `ENTRYPOINT_DEBUG` env variable is set. 

This makes the debug log very verbose tho:

<details>
  <summary>Before</summary>

  ```
  [18-Oct-24_08:28:41] NVIDIA driver container exec start
  [18-Oct-24_08:28:41] OS is Ubuntu
  [18-Oct-24_08:28:41] [os-release]: PRETTY_NAME="Ubuntu 24.04.1 LTS" NAME="Ubuntu" VERSION_ID="24.04" VERSION="24.04.1 LTS (Noble Numbat)" VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian HOME_URL="https://www.ubuntu.com/" SUPPORT_URL="https://help.ubuntu.com/" BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" UBUNTU_CODENAME=noble LOGO=ubuntu-logo
  [18-Oct-24_08:28:41] [uname -a]: Linux b6f3095d2e33 6.8.0-31-generic #31-Ubuntu SMP PREEMPT_DYNAMIC Sat Apr 20 00:40:06 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
  ```
</details>

<details>
  <summary>After</summary>
  
  ```
  + [[ -f /tmp/entrypoint_done ]]
  + timestamp_print 'NVIDIA driver container exec start'
  ++ date +%d-%b-%y_%H:%M:%S
  + date_time_stamp=18-Oct-24_08:07:18
  + msg='[18-Oct-24_08:07:18] NVIDIA driver container exec start'
  + echo '[18-Oct-24_08:07:18] NVIDIA driver container exec start'
  + tee -a /tmp/entrypoint_debug_cmds.log
  [18-Oct-24_08:07:18] NVIDIA driver container exec start
  ++ uname -m
  + ARCH=x86_64
  ++ uname -r
  + FULL_KVER=6.8.0-31-generic
  + IS_OS_UBUNTU=true
  ++ grep -i ubuntu /etc/os-release -c
  + [[ 9 == \0 ]]
  + RHEL_MAJOR_VERSION=0
  + OPENSHIFT_VERSION=
  + DTK_OCP_BUILD_SCRIPT=/root/dtk_nic_driver_build.sh
  + DTK_OCP_START_COMPILE_FLAG=/mnt/shared-nvidia-nic-driver-toolkit/dtk_start_compile
  + DTK_OCP_DONE_COMPILE_FLAG_PREFIX=/mnt/shared-nvidia-nic-driver-toolkit/dtk_done_compile_
  + DTK_OCP_DONE_COMPILE_FLAG=
  + VENDOR=0x15b3
  + DRIVER_PATH=/sys/bus/pci/drivers/mlx5_core
  + MLX_DRIVERS_MOUNT=/run/mellanox/drivers
  + MLX_UDEV_RULES_FILE=/host/etc/udev/rules.d/77-mlnx-net-names.rules
  + SHARED_KERNEL_HEADERS_DIR=/usr/src/
  + BIND_DELAY_SEC=3
  + DRIVER_READY_FILE=/run/mellanox/drivers/.driver-ready
  + new_driver_loaded=false
  + append_driver_build_flags=
  + pkg_dkms_suffix=
  + found_long_mlx_dev_id_net_name_path=false
  + mlx5_core_loaded=false
  ++ lsmod
  ++ grep -i '^mlx5_core' -c
  + [[ 1 != \0 ]]
  + mlx5_core_loaded=true
  + build_src=false
  + build_precompiled=false
  + reuse_driver_inventory=false
  + driver_inventory_path=
  + driver_build_incomplete=false
  + RH_RT_MIN_MAJOR_VER=9
  + declare -a mlx_devs_arr
  + declare -a mlx_vfs_arr
  + declare -a switchdev_representors_arr
  + mlx_dev_record_idx=0
  + true
  + debug_print 'OS is Ubuntu'
  + true
  + timestamp_print OS is Ubuntu
  ++ date +%d-%b-%y_%H:%M:%S
  + date_time_stamp=18-Oct-24_08:07:18
  + msg='[18-Oct-24_08:07:18] OS is Ubuntu'
  + echo '[18-Oct-24_08:07:18] OS is Ubuntu'
  + tee -a /tmp/entrypoint_debug_cmds.log
  [18-Oct-24_08:07:18] OS is Ubuntu
  + pkg_dkms_suffix=-dkms
  ++ cat /etc/os-release
  + debug_print '[os-release]: PRETTY_NAME="Ubuntu' 24.04.1 'LTS"' 'NAME="Ubuntu"' 'VERSION_ID="24.04"' 'VERSION="24.04.1' LTS '(Noble' 'Numbat)"' VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian 'HOME_URL="https://www.ubuntu.com/"' 'SUPPORT_URL="https://help.ubuntu.com/"' 'BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"' 'PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"' UBUNTU_CODENAME=noble LOGO=ubuntu-logo
  + true
  + timestamp_print '[os-release]:' 'PRETTY_NAME="Ubuntu' 24.04.1 'LTS"' 'NAME="Ubuntu"' 'VERSION_ID="24.04"' 'VERSION="24.04.1' LTS '(Noble' 'Numbat)"' VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian 'HOME_URL="https://www.ubuntu.com/"' 'SUPPORT_URL="https://help.ubuntu.com/"' 'BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"' 'PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"' UBUNTU_CODENAME=noble LOGO=ubuntu-logo
  ++ date +%d-%b-%y_%H:%M:%S
  + date_time_stamp=18-Oct-24_08:07:18
  + msg='[18-Oct-24_08:07:18] [os-release]: PRETTY_NAME="Ubuntu 24.04.1 LTS" NAME="Ubuntu" VERSION_ID="24.04" VERSION="24.04.1 LTS (Noble Numbat)" VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian HOME_URL="https://www.ubuntu.com/" SUPPORT_URL="https://help.ubuntu.com/" BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" UBUNTU_CODENAME=noble LOGO=ubuntu-logo'
  + echo '[18-Oct-24_08:07:18] [os-release]: PRETTY_NAME="Ubuntu 24.04.1 LTS" NAME="Ubuntu" VERSION_ID="24.04" VERSION="24.04.1 LTS (Noble Numbat)" VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian HOME_URL="https://www.ubuntu.com/" SUPPORT_URL="https://help.ubuntu.com/" BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" UBUNTU_CODENAME=noble LOGO=ubuntu-logo'
  + tee -a /tmp/entrypoint_debug_cmds.log
  [18-Oct-24_08:07:18] [os-release]: PRETTY_NAME="Ubuntu 24.04.1 LTS" NAME="Ubuntu" VERSION_ID="24.04" VERSION="24.04.1 LTS (Noble Numbat)" VERSION_CODENAME=noble ID=ubuntu ID_LIKE=debian HOME_URL="https://www.ubuntu.com/" SUPPORT_URL="https://help.ubuntu.com/" BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/" PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy" UBUNTU_CODENAME=noble LOGO=ubuntu-logo
  ++ uname -a
  + debug_print '[uname -a]: Linux' e82d8a8dfb57 6.8.0-31-generic '#31-Ubuntu' SMP PREEMPT_DYNAMIC Sat Apr 20 00:40:06 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
  + true
  + timestamp_print '[uname' '-a]:' Linux e82d8a8dfb57 6.8.0-31-generic '#31-Ubuntu' SMP PREEMPT_DYNAMIC Sat Apr 20 00:40:06 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
  ++ date +%d-%b-%y_%H:%M:%S
  + date_time_stamp=18-Oct-24_08:07:18
  ```
</details>