### PR TITLE
feat: add directory for release manifest files

### DIFF
--- a/release_manifests/24.10-0.7.0.0-0.yaml
+++ b/release_manifests/24.10-0.7.0.0-0.yaml
@@ -1,0 +1,32 @@
+precompiled:
+- os: ubuntu24.04
+  arch: [amd64, arm64]
+  kernels: [6.8.0-31-generic, 6.8.0-1016-oracle, 6.8.0-1018-azure, 6.8.0-1019-aws]
+- os: ubuntu22.04
+  arch: [amd64, arm64]
+  kernels: [5.15.0-25-generic, 6.8.0-1016-oracle, 6.8.0-1018-azure, 6.8.0-1019-aws]
+dynamically_compiled:
+- os: ubuntu24.04
+  arch: [amd64, arm64]
+- os: ubuntu22.04
+  arch: [amd64, arm64]
+- os: ubuntu20.04
+  arch: [amd64]
+- os: rhcos4.16
+  arch: [amd64, arm64]
+- os: rhcos4.15
+  arch: [amd64, arm64]
+- os: rhcos4.14
+  arch: [amd64]
+- os: rhel9.4
+  arch: [amd64]
+- os: rhel9.3
+  arch: [amd64]
+- os: rhel9.2
+  arch: [amd64]
+- os: rhel8.10
+  arch: [amd64]
+- os: rhel8.9
+  arch: [amd64]
+- os: rhel8.8
+  arch: [amd64]


### PR DESCRIPTION
The directory retroactively includes a release manifest file listing the doca-driver images of version `24.10-0.7.0.0-0`.