### PR TITLE
Add support for local file paths (as well as URL) for fetching OFED sources

### DIFF
--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -53,7 +53,7 @@ ARG D_OFED_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSIO
 ARG D_OFED_SRC_TYPE=""
 
 ARG D_OFED_SRC_ARCHIVE="MLNX_OFED_SRC-${D_OFED_SRC_TYPE}${D_OFED_VERSION}.tgz"
-ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"
+ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"  # although argument name says URL, local `*.tgz` compressed files may also be used (intended for internal use)
 
 ENV NVIDIA_NIC_DRIVER_VER=${D_OFED_VERSION}
 ENV NVIDIA_NIC_CONTAINER_VER=${D_CONTAINER_VER}
@@ -66,10 +66,15 @@ RUN set -x && \
 # Driver build requirements
     autoconf python3-devel ethtool automake pciutils libtool hostname dracut
 
-RUN set -x && \
-# Download NVIDIA NIC driver sources
-    mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH} && \
-    cd ${D_OFED_SRC_DOWNLOAD_PATH} && (curl -sL ${D_OFED_URL_PATH} | tar -xzf -)
+# Download NVIDIA NIC driver
+RUN mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH}
+WORKDIR ${D_OFED_SRC_DOWNLOAD_PATH}
+ADD ${D_OFED_URL_PATH} ${D_OFED_SRC_ARCHIVE}
+RUN if file ${D_OFED_SRC_ARCHIVE} | grep compressed; then \
+    tar -xzf ${D_OFED_SRC_ARCHIVE} \
+  else \
+    mv ${D_OFED_SRC_ARCHIVE}/MLNX_OFED_SRC-${D_OFED_VERSION} . ; \
+  fi
 
 WORKDIR /
 ADD ./entrypoint.sh /root/entrypoint.sh

--- a/SLES_Dockerfile
+++ b/SLES_Dockerfile
@@ -55,7 +55,7 @@ ARG D_OFED_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSIO
 ARG D_OFED_SRC_TYPE=""
 
 ARG D_OFED_SRC_ARCHIVE="MLNX_OFED_SRC-${D_OFED_SRC_TYPE}${D_OFED_VERSION}.tgz"
-ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"
+ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"  # although argument name says URL, local `*.tgz` compressed files may also be used (intended for internal use)
 
 ENV NVIDIA_NIC_DRIVER_PATH="${D_OFED_SRC_DOWNLOAD_PATH}/MLNX_OFED_SRC-${D_OFED_VERSION}"
 
@@ -69,10 +69,17 @@ RUN set -x && \
     zypper --non-interactive install --no-recommends \
     make autoconf chrpath automake hostname gcc quilt dracut rpm-build sysvinit-tools
 
-RUN set -x && \
-# Download NVIDIA NIC driver sources
-    mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH} && \
-    cd ${D_OFED_SRC_DOWNLOAD_PATH} && (curl -sL ${D_OFED_URL_PATH} | tar -xzf -)
+# Download NVIDIA NIC driver
+RUN mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH}
+WORKDIR ${D_OFED_SRC_DOWNLOAD_PATH}
+ADD ${D_OFED_URL_PATH} ${D_OFED_SRC_ARCHIVE}
+RUN if file ${D_OFED_SRC_ARCHIVE} | grep compressed; then \
+    tar -xzf ${D_OFED_SRC_ARCHIVE} \
+  else \
+    mv ${D_OFED_SRC_ARCHIVE}/MLNX_OFED_SRC-${D_OFED_VERSION} . ; \
+  fi
+
+WORKDIR /root
 
 CMD ["sources"]
 

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -55,8 +55,7 @@ ARG D_OFED_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSIO
 ARG D_OFED_SRC_TYPE="debian-"
 
 ARG D_OFED_SRC_ARCHIVE="MLNX_OFED_SRC-${D_OFED_SRC_TYPE}${D_OFED_VERSION}.tgz"
-ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"
-
+ARG D_OFED_URL_PATH="${D_OFED_BASE_URL}/${D_OFED_SRC_ARCHIVE}"  # although argument name says URL, local `*.tgz` compressed files may also be used (intended for internal use)
 ENV NVIDIA_NIC_DRIVER_PATH="${D_OFED_SRC_DOWNLOAD_PATH}/MLNX_OFED_SRC-${D_OFED_VERSION}"
 
 WORKDIR /root
@@ -70,10 +69,17 @@ RUN set -x && \
 
 RUN ln -fs gcc-12 /usr/bin/gcc  # 'build-essential' installs `gcc`, however we need `gcc-12`, so we overwrite it with this link
 
-RUN set -x && \
-# Download NVIDIA NIC driver sources
-    mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH} && \
-    cd ${D_OFED_SRC_DOWNLOAD_PATH} && (curl -sL ${D_OFED_URL_PATH} | tar -xzf -)
+# Download NVIDIA NIC driver
+RUN mkdir -p ${D_OFED_SRC_DOWNLOAD_PATH}
+WORKDIR ${D_OFED_SRC_DOWNLOAD_PATH}
+ADD ${D_OFED_URL_PATH} ${D_OFED_SRC_ARCHIVE}
+RUN if file ${D_OFED_SRC_ARCHIVE} | grep compressed; then \
+    tar -xzf ${D_OFED_SRC_ARCHIVE} \
+  else \
+    mv ${D_OFED_SRC_ARCHIVE}/MLNX_OFED_SRC-${D_OFED_VERSION} . ; \
+  fi
+
+WORKDIR /root
 
 CMD ["sources"]
 


### PR DESCRIPTION
Reminder about the logic of [Dockerfile ADD instruction](https://docs.docker.com/reference/dockerfile/#add):
> - In `ADD <src> <dest>` the `<src>` can be a local file path or remote URL.
> - If `<src>` is a local tar archive, it is decompressed and extracted to the specified `<dest>`.
> - If `<src>` is a remote tar archive, it is **not** decompressed nor extracted. It will be added to the image still in its _compressed_ format.

...hence the logic in the changes in this PR. 