### PR TITLE
fix: ease rpm install package selection

### DIFF
--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -124,14 +124,7 @@ ENV NVIDIA_NIC_CONTAINER_VER=${D_CONTAINER_VER}
 
 COPY --from=driver-builder ${OFED_SRC_LOCAL_DIR}/RPMS/redhat-release-*/${D_ARCH}/*.rpm /root/
 
-WORKDIR /root/
-RUN set -x && \
-    rpm -ivh --nodeps \
-    ./kmod-mlnx-nfsrdma-*.rpm \
-    ./kmod-mlnx-nvme-*.rpm \
-    ./kmod-mlnx-ofa_kernel-*.rpm \
-    ./mlnx-ofa_kernel-*.rpm \
-    ./mlnx-tools-*.rpm
+RUN rpm -ivh --nodeps /root/*.rpm
 
 RUN set -x && \
 # MOFED functional requirements


### PR DESCRIPTION
This change will slightly bloat RHEL/RHCOS images, in exchange for simplifying (and enabling!) precompiled builds. This is due to some architectures/variants requiring (or not) certain packages that the Dockerfile builds.