### PR TITLE
fix: inheret build-arg within multistage docker build

### DIFF
--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -46,6 +46,7 @@ ENTRYPOINT ["/root/entrypoint.sh"]
 FROM base AS driver-src
 
 # Inherited global args
+ARG D_OS
 ARG D_DOCA_VERSION
 ARG D_OFED_VERSION
 ARG D_OFED_SRC_DOWNLOAD_PATH


### PR DESCRIPTION
Previous fix was tested with single stage Dockerfile instead of _multistage_.
This fix enables the previous fix to work with the actual Dockerfile.