### PR TITLE
chore: set flavor names for 25.04

### DIFF
--- a/release_manifests/25.04.yaml
+++ b/release_manifests/25.04.yaml
@@ -4,14 +4,12 @@ precompiled:
   archs:
   - amd64
   - arm64
-  kernels:
-  - 9.9.0-106-mockflavor
+  kernels: [generic, nvidia, azure, aws, oracle]
 - os: ubuntu22.04
   archs:
   - amd64
   - arm64
-  kernels:
-  - 9.9.0-106-mockflavor
+  kernels: [generic, nvidia, azure, aws, oracle]
 dynamically_compiled:
 - os: ubuntu24.04
   archs:


### PR DESCRIPTION
flavor names must be stated so new CI can correctly parse them and build. 