### PR TITLE
bug: load mlx5_vdpa explicitly

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -509,6 +509,11 @@ function restart_driver() {
     ${UNLOAD_STORAGE_MODULES} && unload_storage_modules
 
     exec_cmd "/etc/init.d/openibd restart"
+
+    # Explicitly load the mlx5_vdpa module from the container to prevent loading an incompatible version from the host.
+    # In Ubuntu 24.04, the inbox (built-in) mlx5_vdpa module is automatically loaded due to the "alias: auxiliary:mlx5_core.vnet" entry.
+    exec_cmd "modprobe mlx5_vdpa"
+
     remove_ofed_modules_blacklist
 
 }


### PR DESCRIPTION
On Ubuntu 24.04, the inbox driver module `mlx5_vdpa` is configured with an `alias` that cause the module to be loaded automatically when a device or function requests `mlx5_core.vnet`.

```
# modinfo mlx5_vdpa
filename:       /lib/modules/6.8.0-55-generic/kernel/drivers/vdpa/mlx5/mlx5_vdpa.ko.zst
license:        Dual BSD/GPL
description:    Mellanox VDPA driver
author:         Eli Cohen <eli@mellanox.com>
srcversion:     C234B0444F53048C69B247D
alias:          auxiliary:mlx5_core.vnet
depends:        mlx5_core,vhost_iotlb,vringh,vdpa
....
```

The inbox  `mlx5_vdpa` is not compatible with the `mlx5_core` from the container, causing `dmesg` errors as follow:

```
[15441.935171] mlx5_vdpa: disagrees about version of symbol mlx5_db_free
[15441.935176] mlx5_vdpa: Unknown symbol mlx5_db_free (err -22)
[15441.935196] mlx5_vdpa: disagrees about version of symbol mlx5_flow_table_id
[15441.935197] mlx5_vdpa: Unknown symbol mlx5_flow_table_id (err -22)
[15441.935205] mlx5_vdpa: disagrees about version of symbol mlx5_query_nic_vport_mtu
[15441.935207] mlx5_vdpa: Unknown symbol mlx5_query_nic_vport_mtu (err -22)
...
```
With this commit, the `mlx5_vdpa` module is loaded explicitly in the container flow after running `/etc/init.d/openibd restart` to avoid the errors.
