### PR TITLE
bug: Load mlx5_vdpa only if present

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -516,7 +516,17 @@ function restart_driver() {
 
     # Explicitly load the mlx5_vdpa module from the container to prevent loading an incompatible version from the host.
     # In Ubuntu 24.04, the inbox (built-in) mlx5_vdpa module is automatically loaded due to the "alias: auxiliary:mlx5_core.vnet" entry.
-    exec_cmd "modprobe mlx5_vdpa"
+    # Load mlx5_vdpa only if present
+
+    if modinfo mlx5_vdpa &>/dev/null; then
+        if ${IS_OS_SLES}; then
+            exec_cmd "modprobe --allow-unsupported mlx5_vdpa"
+        else
+            exec_cmd "modprobe mlx5_vdpa"
+        fi
+    else
+        debug_print "mlx5_vdpa module not found; skipping"
+    fi
 
     remove_ofed_modules_blacklist
 


### PR DESCRIPTION
- Check if module exists before trying to load it
- For SLES use allow-unsupported flag

SLES error:

```
++ eval 'modprobe mlx5_vdpa'
+++ modprobe mlx5_vdpa
modprobe: ERROR: module 'mlx5_vdpa' is unsupported
modprobe: ERROR: Use --allow-unsupported or set allow_unsupported_modules 1 in
modprobe: ERROR: /etc/modprobe.d/10-unsupported-modules.conf
modprobe: ERROR: could not insert 'mlx5_vdpa': Operation not permitted
+ output=
+ exit_code=1
+ echo ''
```

RHEL ARM error:

```
[25-Mar-25_13:49:33] Executing command: modprobe mlx5_vdpa
++ eval 'modprobe mlx5_vdpa'
+++ modprobe mlx5_vdpa
modprobe: FATAL: Module mlx5_vdpa not found in directory /lib/modules/5.14.0-503.11.1.el9_5.aarch64
+ output=
+ exit_code=1
+ echo ''

+ [[ 1 -ne 0 ]]
+ timestamp_print 'Command "modprobe mlx5_vdpa" failed with exit code: 1'
++ date +%d-%b-%y_%H:%M:%S
+ date_time_stamp=25-Mar-25_13:49:33
+ msg='[25-Mar-25_13:49:33] Command "modprobe mlx5_vdpa" failed with exit code: 1'
+ echo '[25-Mar-25_13:49:33] Command "modprobe mlx5_vdpa" failed with exit code: 1'
```