### PR TITLE
feat: add doca_version field to modern release manifests

### DIFF
--- a/release_manifests/24.10.yaml
+++ b/release_manifests/24.10.yaml
@@ -1,4 +1,5 @@
 driver_version: 24.10-0.7.0.0-0
+doca_version: 2.9.0
 precompiled:
 - os: ubuntu24.04
   archs: [amd64, arm64]

--- a/release_manifests/25.01.yaml
+++ b/release_manifests/25.01.yaml
@@ -1,4 +1,5 @@
 driver_version: 25.01-0.6.0.0-0
+doca_version: 2.10.0
 precompiled:
 - os: ubuntu24.04
   archs: [amd64, arm64]

--- a/release_manifests/25.04.yaml
+++ b/release_manifests/25.04.yaml
@@ -1,4 +1,5 @@
 driver_version: 25.04-0.2.9.0-0
+doca_version: 3.0.0
 precompiled:
 - os: ubuntu24.04
   archs:


### PR DESCRIPTION
The `doca_version` value will later be used by:
- Precompiled DOCA CI (instead of looking up labels from existing dynamically compiled image).
- nSpect automation (internal) - for defining appropriate DOCA version to set in dependency tree.

Value _not_ set in older versions (no longer relevant), nor for LTS - because TBD.