### PR TITLE
fix: add missing package dependencies for precompiled builds

### DIFF
--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -50,6 +50,7 @@ ARG D_OS
 ARG D_DOCA_VERSION
 ARG D_OFED_VERSION
 ARG D_OFED_SRC_DOWNLOAD_PATH
+ARG D_KERNEL_VER
 
 # Stage args
 ARG D_OFED_BASE_URL="https://linux.mellanox.com/public/repo/doca/${D_DOCA_VERSION}/SOURCES/MLNX_OFED"
@@ -64,7 +65,7 @@ RUN set -x && \
     echo $D_OS | grep "ubuntu20.04" || GCC_VER="-12" && \
 # Install prerequirements \
     DEBIAN_FRONTEND=noninteractive apt-get -yq install curl \
-    dkms make autoconf autotools-dev chrpath automake hostname debhelper gcc$GCC_VER quilt libc6-dev build-essential pkg-config && \
+    dkms make autoconf autotools-dev chrpath automake hostname debhelper gcc$GCC_VER quilt libc6-dev build-essential pkg-config linux-modules-extra-${D_KERNEL_VER} && \
 # Cleanup \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/*

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -123,7 +123,7 @@ ARG OFED_SRC_LOCAL_DIR
 ENV NVIDIA_NIC_DRIVER_PATH=""
 
 RUN set -x && \
-    apt-get install -y lsb-release && \
+    apt-get install -y lsb-release linux-modules-extra-${D_KERNEL_VER} && \
 # Cleanup
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This fixes precompiled DOCA driver builds failing.

Root cause was when installing `*.deb` packages with `dpkg -i`, a dependency (what was added in this PR) wouldn't get resolved.

```
dpkg: error processing package mlnx-ofed-kernel-modules (--install):
dependency problems - leaving unconfigured
dpkg: dependency problems prevent configuration of srp-modules:
srp-modules depends on mlnx-ofed-kernel-modules; however:
  Package mlnx-ofed-kernel-modules is not configured yet.
```