### PR TITLE
fix: use apt instead of dpkg to install packages without breaking dependencies

### DIFF
--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -123,8 +123,10 @@ ARG OFED_SRC_LOCAL_DIR
 ENV NVIDIA_NIC_DRIVER_PATH=""
 
 RUN set -x && \
-    apt-get install -y lsb-release linux-modules-extra-${D_KERNEL_VER} && \
+    apt-get install -y lsb-release && \
+    if echo $D_KERNEL_VER | grep .; then apt-get install -y linux-modules-extra-${D_KERNEL_VER}; fi  # only install this package when kernel variable defined
 # Cleanup
+RUN set -x && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1103,7 +1103,7 @@ function install_driver() {
     exec_cmd "touch /lib/modules/${FULL_KVER}/modules.builtin"
 
     if ${IS_OS_UBUNTU}; then
-        exec_cmd "dpkg -i ${driver_inventory_path}/*.deb"
+        exec_cmd "apt-get install -y ${driver_inventory_path}/*.deb"
     else
         exec_cmd "rpm -ivh --replacepkgs --nodeps ${driver_inventory_path}/*.rpm"
     fi


### PR DESCRIPTION
original error:
```
dpkg: dependency problems prevent configuration of mlnx-ofed-kernel-modules:
  mlnx-ofed-kernel-modules depends on linux-modules-extra-6.8.0-1023-oracle; however:
   Package linux-modules-extra-6.8.0-1023-oracle is not installed
```

solution for precompiled builds:
- if the kernel version is known: install the missing dependency in advanced (in theory it should always be known, but this logic is implemented to not break some upstream CI).

solution for dynamically compiled builds - use apt instead of dpkg to install packages without breaking dependency graph:
- the wildcard glob gets expanded alphabetically.
- `dpkg -i` installs packages "stupidly" in the order it received them.
- `apt-get install` can "smartly" resolve the packages' dependencies, thus is not sensitive to the order of the expanded glob (and thus fixing the issue).