### PR TITLE
fix: install missing dependency before installing local driver packages

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1103,7 +1103,7 @@ function install_driver() {
     exec_cmd "touch /lib/modules/${FULL_KVER}/modules.builtin"
 
     if ${IS_OS_UBUNTU}; then
-        exec_cmd "apt-get install -y ${driver_inventory_path}/*.deb"
+        exec_cmd "apt-get install -y linux-modules-extra-${FULL_KVER} ${driver_inventory_path}/*.deb"
     else
         exec_cmd "rpm -ivh --replacepkgs --nodeps ${driver_inventory_path}/*.rpm"
     fi


### PR DESCRIPTION
Issue caught in Network Operator automated checks:
https://github.com/Mellanox/network-operator/pull/1450#issuecomment-2826996235

This solution should install the missing dependency package before installing the locally built packages.