### PR TITLE
fix: support custom CA certificate update on Ubuntu in entrypoint

### DIFF
--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -33,7 +33,7 @@ RUN set -x && \
 # Driver build / install script requirements
     perl pciutils kmod lsof python3 dh-python \
 # Container functional requirements
-    jq iproute2 udev ethtool
+    jq iproute2 udev ethtool ca-certificates
 
 WORKDIR /
 ADD ./entrypoint.sh /root/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1313,6 +1313,18 @@ function print_loaded_drv_ver_str() {
     fi
 }
 
+function update_ca_certificates() {
+    if ${IS_OS_UBUNTU}; then
+        timestamp_print "Updating system CA certificates (Ubuntu)..."
+
+        if command -v update-ca-certificates >/dev/null 2>&1; then
+            exec_cmd "update-ca-certificates || true"
+        else
+            timestamp_print "[WARN] update-ca-certificates not found"
+        fi
+    fi
+}
+
 ############################## Exec start #####################################
 if ${ENTRYPOINT_DEBUG}; then
     set -x
@@ -1371,6 +1383,7 @@ else
     debug_print "OS is Red Hat"
     redhat_fetch_major_ver
 fi
+update_ca_certificates
 
 debug_print "[os-release]: "$(cat /etc/os-release)
 debug_print "[uname -a]: "$(uname -a)


### PR DESCRIPTION
This PR moves the custom CA certificate update logic (`update-ca-certificates`) into the container's entrypoint.sh for Ubuntu-based OFED driver deployments.

- Added `update_ca_certificates` function to `entrypoint.sh` and invoked it early during startup.
- Installed the `ca-certificates` package in `Ubuntu_Dockerfile` to ensure the command is available inside the container.

This ensures custom CAs mounted via certConfig in NicClusterPolicy are correctly applied during container initialization. 