### PR TITLE
fix: use without-dkms for all OSes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -369,13 +369,12 @@ function build_driver_from_src() {
     sub_path_str="RPMS"
     os_str="redhat"
     package_type="rpm"
-    append_driver_build_flags="$append_driver_build_flags --disable-kmp"
+    append_driver_build_flags="$append_driver_build_flags --disable-kmp --without-dkms"
 
     if ${IS_OS_UBUNTU}; then
         sub_path_str="DEBS"
         os_str="ubuntu"
         package_type="deb"
-        append_driver_build_flags="$append_driver_build_flags --without-dkms"
     fi
 
     if ${IS_OS_SLES}; then

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -782,11 +782,11 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 	switch osType {
 	case constants.OSTypeUbuntu:
-		return []string{"--without-dkms"}
+		return []string{"--disable-kmp", "--without-dkms"}
 	case constants.OSTypeSLES:
-		return []string{"--disable-kmp", "--kernel-sources", "/lib/modules/" + kernelVersion + "/build"}
+		return []string{"--disable-kmp", "--without-dkms", "--kernel-sources", "/lib/modules/" + kernelVersion + "/build"}
 	case constants.OSTypeRedHat:
-		return []string{"--disable-kmp"}
+		return []string{"--disable-kmp", "--without-dkms"}
 	default:
 		return []string{}
 	}

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -944,7 +944,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
@@ -1001,7 +1001,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-default", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem", "--without-iser",
 				"--without-isert", "--without-srp", "--without-kernel-mft",
-				"--without-mlnx-rdma-rxe", "--disable-kmp", "--kernel-sources",
+				"--without-mlnx-rdma-rxe", "--disable-kmp", "--without-dkms", "--kernel-sources",
 				"/lib/modules/5.4.0-42-default/build", "--without-mlnx-nfsrdma",
 				"--without-mlnx-nvme").Return("", "", nil)
 
@@ -1066,7 +1066,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem", "--without-iser",
 				"--without-isert", "--without-srp", "--without-kernel-mft",
-				"--without-mlnx-rdma-rxe", "--disable-kmp", "--without-mlnx-nfsrdma",
+				"--without-mlnx-rdma-rxe", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma",
 				"--without-mlnx-nvme").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
@@ -1218,7 +1218,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", expectedError)
 
 			err := dm.Build(ctx)
@@ -1251,7 +1251,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", nil)
 
 			// Mock copyBuildArtifacts failure - debug logging and copy failure
@@ -1300,7 +1300,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
@@ -1337,7 +1337,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
@@ -1415,7 +1415,7 @@ var _ = Describe("Driver", func() {
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
 				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--without-dkms", "--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms", "--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy


### PR DESCRIPTION
In DOCA 3.2, dkms was introduced to RHEL and SLES, in addition to
existing support for Ubuntu.

Currently, DOCA OFED Driver container does not support dkms.
Therefore, aligining all OSes to not use dkms.