### PR TITLE
feat: add STIG-compliant variant to release manifest

### DIFF
--- a/release_manifests/25.10.yaml
+++ b/release_manifests/25.10.yaml
@@ -21,6 +21,9 @@ precompiled:
   - 6.8.0-1040-azure
   - 6.8.0-1040-nvidia
 dynamically_compiled:
+- os: ubuntu24.04-stig
+  archs:
+  - amd64
 - os: ubuntu24.04
   archs:
   - amd64


### PR DESCRIPTION
this PR is coupled with https://github.com/Mellanox/network-operator/pull/1776 and with the merge request in our internal CI (so should be merged at the ‘same’ time).