### PR TITLE
Revert "feat: add STIG-compliant variant to release manifest"

### DIFF
--- a/release_manifests/25.10.yaml
+++ b/release_manifests/25.10.yaml
@@ -21,9 +21,6 @@ precompiled:
   - 6.8.0-1040-azure
   - 6.8.0-1040-nvidia
 dynamically_compiled:
-- os: ubuntu24.04-stig
-  archs:
-  - amd64
 - os: ubuntu24.04
   archs:
   - amd64


### PR DESCRIPTION
Reverts Mellanox/doca-driver-build#163, since coupled PRs (main one on internal GitLab) not yet reviewed/merged...!