### PR TITLE
Add UNLOAD_THIRD_PARTY_RDMA_MODULES to blacklist and unload known

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ podman pull --authfile=/path/to/pull-secret.txt docker://quay.io/openshift-relea
     --target precompiled .
 ```
 
+## Runtime Environment Variables
+
+The following environment variables can be set at container runtime to control driver loading behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OFED_BLACKLIST_MODULES` | `mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm` | Colon-separated list of OFED kernel modules to blacklist on the host. |
+| `UNLOAD_THIRD_PARTY_RDMA_MODULES` | `false` | When `true`, all known third-party RDMA kernel modules (from rdma-core: qedr, efa, siw, etc.) are blacklisted and unloaded before OFED driver reload. The module list is hardcoded. |
+| `UNLOAD_STORAGE_MODULES` | `false` | When `true`, storage modules (ib_isert, nvme_rdma, etc.) are unloaded during driver restart. |
+| `RESTORE_DRIVER_ON_POD_TERMINATION` | `false` | When `true`, restores the inbox driver on container teardown. |
+
 >[!IMPORTANT]
 >Dockerfiles contain default build parameters, which may fail build proccess on your system if not overridden.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,6 +50,15 @@
 : ${OFED_BLACKLIST_MODULES_FILE:=/host/etc/modprobe.d/blacklist-ofed-modules.conf}
 : ${OFED_BLACKLIST_MODULES:=mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm}
 
+# UNLOAD_THIRD_PARTY_RDMA_MODULES: when true, all known third-party RDMA kernel
+# modules (from rdma-core) are blacklisted and unloaded before OFED driver reload.
+# The module list is hardcoded — no user input needed.
+# Example: UNLOAD_THIRD_PARTY_RDMA_MODULES=true
+: ${UNLOAD_THIRD_PARTY_RDMA_MODULES:=false}
+
+# Hardcoded list of known third-party RDMA modules (non-NVIDIA, from rdma-core)
+THIRD_PARTY_RDMA_MODULES="bnxt_re efa erdma iw_cxgb4 hfi1 hns_roce ionic_rdma irdma ib_qib mana_ib ocrdma qedr rdma_rxe siw vmw_pvrdma ib_srp ib_iser iw_cm ib_isert nvme_rdma nvmet_rdma rpcrdma xprtrdma"
+
 : ${UBUNTU_PRO_TOKEN:=""}
 
 : ${USE_DKMS:=false}
@@ -504,6 +513,27 @@ function unload_storage_modules() {
     fi
 }
 
+function unload_third_party_rdma_modules() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    timestamp_print "Extending modules unload list with third-party RDMA modules: ${THIRD_PARTY_RDMA_MODULES}"
+    unload_script="/etc/init.d/openibd"
+    if [ -f "/usr/share/mlnx_ofed/mod_load_funcs" ]; then
+        unload_script="/usr/share/mlnx_ofed/mod_load_funcs"
+    fi
+
+    # Pick the first module to verify injection
+    local first_mod
+    first_mod=$(echo "${THIRD_PARTY_RDMA_MODULES}" | awk '{print $1}')
+
+    sed -i -e "/^[[:space:]]*UNLOAD_MODULES=\"[a-z]/a\\    UNLOAD_MODULES=\"\$UNLOAD_MODULES ${THIRD_PARTY_RDMA_MODULES}\"" ${unload_script}
+
+    if ! grep -q "UNLOAD_MODULES=.*${first_mod}" "${unload_script}"; then
+        timestamp_print "Failed to inject third-party RDMA modules for unload"
+        exit_entryp 1
+    fi
+}
+
 function generate_ofed_modules_blacklist(){
     echo "Function: ${FUNCNAME[0]}"
 
@@ -515,6 +545,14 @@ function generate_ofed_modules_blacklist(){
     for component in "${components[@]}"; do
         echo "blacklist $component" >> ${OFED_BLACKLIST_MODULES_FILE}
     done
+
+    # Append third-party RDMA modules to blacklist if enabled
+    if ${UNLOAD_THIRD_PARTY_RDMA_MODULES}; then
+        echo -e "\n# blacklist third-party RDMA modules to prevent reload conflicts" >> ${OFED_BLACKLIST_MODULES_FILE}
+        for mod in ${THIRD_PARTY_RDMA_MODULES}; do
+            echo "blacklist $mod" >> ${OFED_BLACKLIST_MODULES_FILE}
+        done
+    fi
 
     debug_print "`cat ${OFED_BLACKLIST_MODULES_FILE}`"
 }
@@ -560,6 +598,7 @@ function restart_driver() {
     trap 'remove_ofed_modules_blacklist' EXIT
     generate_ofed_modules_blacklist
     ${UNLOAD_STORAGE_MODULES} && unload_storage_modules
+    ${UNLOAD_THIRD_PARTY_RDMA_MODULES} && unload_third_party_rdma_modules
 
     exec_cmd "/etc/init.d/openibd restart"
 

--- a/entrypoint/.golangci.yaml
+++ b/entrypoint/.golangci.yaml
@@ -97,6 +97,8 @@ linters-settings:
     line-length: 140
   misspell:
     locale: US
+    ignore-words:
+      - lustre
   stylecheck:
     checks: ["all", "-ST1000"]
     dot-import-whitelist:

--- a/entrypoint/internal/config/config.go
+++ b/entrypoint/internal/config/config.go
@@ -55,12 +55,31 @@ type Config struct {
 
 	// DKMS settings
 	UseDKMS bool `env:"USE_DKMS" envDefault:"false"`
+	// UnloadThirdPartyRdmaModules enables blacklisting and unloading of all known
+	// third-party RDMA kernel modules (from rdma-core) before OFED driver reload.
+	// When true, modules from ThirdPartyRDMAModules are:
+	//   1. Added to the modprobe blacklist file (prevents auto-reload by the kernel)
+	//   2. Injected into openibd's UNLOAD_MODULES list (unloaded during driver restart)
+	//
+	// Example: UNLOAD_THIRD_PARTY_RDMA_MODULES=true
+	UnloadThirdPartyRdmaModules bool `env:"UNLOAD_THIRD_PARTY_RDMA_MODULES"`
 
 	// debug settings
 	EntrypointDebug     bool   `env:"ENTRYPOINT_DEBUG"`
 	DebugLogFile        string `env:"DEBUG_LOG_FILE"          envDefault:"/tmp/entrypoint_debug_cmds.log"`
 	DebugSleepSecOnExit int    `env:"DEBUG_SLEEP_SEC_ON_EXIT" envDefault:"300"`
 	BindDelaySec        int    `env:"BIND_DELAY_SEC"          envDefault:"4"`
+}
+
+// ThirdPartyRDMAModules is the hardcoded list of known third-party RDMA kernel modules
+// (non-NVIDIA modules from the rdma-core ecosystem) that can block MOFED driver reload.
+// This list is used when UnloadThirdPartyRdmaModules is true.
+var ThirdPartyRDMAModules = []string{
+	"bnxt_re", "efa", "erdma", "iw_cxgb4", "hfi1", "hns_roce",
+	"ionic_rdma", "irdma", "ib_qib", "mana_ib", "ocrdma", "qedr",
+	"rdma_rxe", "siw", "vmw_pvrdma",
+	"ib_srp", "ib_iser", "iw_cm", "ib_isert",
+	"nvme_rdma", "nvmet_rdma", "rpcrdma", "xprtrdma",
 }
 
 // GetConfig parses environment variables and returns a Config struct.

--- a/entrypoint/internal/config/config_suite_test.go
+++ b/entrypoint/internal/config/config_suite_test.go
@@ -1,0 +1,29 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/entrypoint/internal/config/config_test.go
+++ b/entrypoint/internal/config/config_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config", func() {
+	// NVIDIA_NIC_DRIVER_VER is required by env parsing, so we must set it.
+	BeforeEach(func() {
+		os.Setenv("NVIDIA_NIC_DRIVER_VER", "25.04-0.6.0.0")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv("NVIDIA_NIC_DRIVER_VER")
+		os.Unsetenv("UNLOAD_THIRD_PARTY_RDMA_MODULES")
+	})
+
+	Context("UnloadThirdPartyRdmaModules", func() {
+		It("should default to false when UNLOAD_THIRD_PARTY_RDMA_MODULES is not set", func() {
+			os.Unsetenv("UNLOAD_THIRD_PARTY_RDMA_MODULES")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UnloadThirdPartyRdmaModules).To(BeFalse())
+		})
+
+		It("should be true when set to \"true\"", func() {
+			os.Setenv("UNLOAD_THIRD_PARTY_RDMA_MODULES", "true")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UnloadThirdPartyRdmaModules).To(BeTrue())
+		})
+
+		It("should be false when set to \"false\"", func() {
+			os.Setenv("UNLOAD_THIRD_PARTY_RDMA_MODULES", "false")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UnloadThirdPartyRdmaModules).To(BeFalse())
+		})
+	})
+})

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -804,13 +804,22 @@ func (d *driverMgr) generateOfedModulesBlacklist(ctx context.Context) error {
 		log.V(2).Info("Added module to blacklist", "module", module)
 	}
 
+	if d.cfg.UnloadThirdPartyRdmaModules {
+		content.WriteString("\n# blacklist third-party RDMA modules to prevent reload conflicts\n")
+		for _, module := range config.ThirdPartyRDMAModules {
+			content.WriteString(fmt.Sprintf("blacklist %s\n", module))
+			log.V(2).Info("Added third-party RDMA module to blacklist", "module", module)
+		}
+	}
+
 	// Write all content at once
 	if _, err := file.WriteString(content.String()); err != nil {
 		log.Error(err, "Failed to write blacklist content to file")
 		return fmt.Errorf("failed to write blacklist content to file: %w", err)
 	}
 
-	log.Info("Successfully generated OFED modules blacklist", "file", d.cfg.OfedBlacklistModulesFile, "modules", d.cfg.OfedBlacklistModules)
+	log.Info("Successfully generated OFED modules blacklist", "file", d.cfg.OfedBlacklistModulesFile,
+		"ofedModules", d.cfg.OfedBlacklistModules, "unloadThirdPartyRdma", d.cfg.UnloadThirdPartyRdmaModules)
 	return nil
 }
 

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -3741,6 +3741,96 @@ var _ = Describe("Driver OFED Blacklist", func() {
 			}
 			Expect(blacklistLines).To(Equal(1))
 		})
+
+		It("should include third-party RDMA modules in blacklist when flag is true", func() {
+			blacklistFile := filepath.Join(tempDir, "third-party-rdma-blacklist.conf")
+			cfg := config.Config{
+				OfedBlacklistModulesFile:     blacklistFile,
+				OfedBlacklistModules:         []string{"mlx5_core", "mlx5_ib"},
+				UnloadThirdPartyRdmaModules: true,
+			}
+
+			dm = &driverMgr{
+				cfg:  cfg,
+				cmd:  cmdMock,
+				host: hostMock,
+				os:   wrappers.NewOS(),
+			}
+
+			err := dm.generateOfedModulesBlacklist(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify file exists
+			_, err = os.Stat(blacklistFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Read and verify content
+			content, err := os.ReadFile(blacklistFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			contentStr := string(content)
+			Expect(contentStr).To(ContainSubstring("# blacklist ofed-related modules on host to prevent inbox or host OFED driver loading"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_core"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_ib"))
+			Expect(contentStr).To(ContainSubstring("# blacklist third-party RDMA modules to prevent reload conflicts"))
+			// Verify a few representative third-party modules
+			Expect(contentStr).To(ContainSubstring("blacklist bnxt_re"))
+			Expect(contentStr).To(ContainSubstring("blacklist qedr"))
+			Expect(contentStr).To(ContainSubstring("blacklist nvme_rdma"))
+			Expect(contentStr).To(ContainSubstring("blacklist xprtrdma"))
+
+			// Count blacklist lines - should be 2 OFED + len(ThirdPartyRDMAModules)
+			lines := strings.Split(contentStr, "\n")
+			blacklistLines := 0
+			for _, line := range lines {
+				if strings.HasPrefix(strings.TrimSpace(line), "blacklist") {
+					blacklistLines++
+				}
+			}
+			Expect(blacklistLines).To(Equal(2 + len(config.ThirdPartyRDMAModules)))
+		})
+
+		It("should not include third-party RDMA modules section when flag is false", func() {
+			blacklistFile := filepath.Join(tempDir, "no-third-party-rdma-blacklist.conf")
+			cfg := config.Config{
+				OfedBlacklistModulesFile:     blacklistFile,
+				OfedBlacklistModules:         []string{"mlx5_core", "mlx5_ib"},
+				UnloadThirdPartyRdmaModules: false,
+			}
+
+			dm = &driverMgr{
+				cfg:  cfg,
+				cmd:  cmdMock,
+				host: hostMock,
+				os:   wrappers.NewOS(),
+			}
+
+			err := dm.generateOfedModulesBlacklist(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify file exists
+			_, err = os.Stat(blacklistFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Read and verify content
+			content, err := os.ReadFile(blacklistFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			contentStr := string(content)
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_core"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_ib"))
+			Expect(contentStr).NotTo(ContainSubstring("# blacklist third-party RDMA modules to prevent reload conflicts"))
+
+			// Count blacklist lines - should be 2 (only OFED)
+			lines := strings.Split(contentStr, "\n")
+			blacklistLines := 0
+			for _, line := range lines {
+				if strings.HasPrefix(strings.TrimSpace(line), "blacklist") {
+					blacklistLines++
+				}
+			}
+			Expect(blacklistLines).To(Equal(2))
+		})
 	})
 
 	Context("removeOfedModulesBlacklist", func() {

--- a/entrypoint/internal/entrypoint/entrypoint.go
+++ b/entrypoint/internal/entrypoint/entrypoint.go
@@ -272,9 +272,10 @@ func (e *entrypoint) createUDEVRulesIfRequired(ctx context.Context) error {
 }
 
 // handleKernelModules function ensures the nvidia_peermem module is unloaded
-// and confirms storage modules will unload during openibd restart.
+// and confirms storage and third-party RDMA modules will unload during openibd restart.
 func (e *entrypoint) handleKernelModules(ctx context.Context) error {
 	e.log.Info("Verifying loaded modules will not prevent future driver restart")
+
 	loadedModules, err := e.host.LsMod(ctx)
 	if err != nil {
 		e.log.Error(err, "failed to list loaded kernel modules")
@@ -297,16 +298,30 @@ func (e *entrypoint) handleKernelModules(ctx context.Context) error {
 	}
 	if e.config.UnloadStorageModules {
 		// storage modules will be unloaded by the openibd restart, no need to check if they are loaded
-		return nil
-	}
-	for _, mod := range e.config.StorageModules {
-		if _, found := loadedModules[mod]; found {
-			err = fmt.Errorf("storage modules are loaded for current driver," +
-				"terminating prior driver reload failure due to UNLOAD_STORAGE_MODULES not set to \"true\"")
-			e.log.Error(err, "kernel modules check failed")
-			return err
+	} else {
+		for _, mod := range e.config.StorageModules {
+			if _, found := loadedModules[mod]; found {
+				err = fmt.Errorf("storage modules are loaded for current driver," +
+					"terminating prior driver reload failure due to UNLOAD_STORAGE_MODULES not set to \"true\"")
+				e.log.Error(err, "kernel modules check failed")
+				return err
+			}
 		}
 	}
+	if e.config.UnloadThirdPartyRdmaModules {
+		// third-party RDMA modules will be unloaded by the openibd restart, no need to check if they are loaded
+	} else {
+		for _, mod := range config.ThirdPartyRDMAModules {
+			if _, found := loadedModules[mod]; found {
+				err = fmt.Errorf("third-party RDMA modules are loaded for current driver," +
+					"terminating prior driver reload failure due to " +
+					"UNLOAD_THIRD_PARTY_RDMA_MODULES not set to \"true\"")
+				e.log.Error(err, "kernel modules check failed")
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/entrypoint/internal/entrypoint/module_deps.go
+++ b/entrypoint/internal/entrypoint/module_deps.go
@@ -1,0 +1,228 @@
+/*
+ Copyright 2026, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package entrypoint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ModuleInfo holds parsed information about a kernel module from /proc/modules.
+type ModuleInfo struct {
+	// Name is the module name.
+	Name string
+	// UserCount is the reference count (number of users) from /proc/modules.
+	UserCount int
+	// DependsOn lists the modules that use (depend on) this one,
+	// as parsed from field 4 of /proc/modules.
+	DependsOn []string
+}
+
+// ParseProcModules reads and parses /proc/modules (or a compatible file) into a map keyed by module name.
+// /proc/modules format: name size refcount dep1,dep2,... state address
+// deps are comma-separated users of this module with a trailing comma, or "-" if none.
+func ParseProcModules(procModulesPath string) (map[string]ModuleInfo, error) {
+	data, err := os.ReadFile(procModulesPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", procModulesPath, err)
+	}
+
+	modules := make(map[string]ModuleInfo)
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue // malformed line, skip
+		}
+
+		name := fields[0]
+		refCount, err := strconv.Atoi(fields[2])
+		if err != nil {
+			refCount = 0
+		}
+
+		var deps []string
+		depsField := fields[3]
+		if depsField != "-" {
+			// deps are comma-separated with a trailing comma
+			parts := strings.Split(strings.TrimRight(depsField, ","), ",")
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					deps = append(deps, p)
+				}
+			}
+		}
+
+		modules[name] = ModuleInfo{
+			Name:      name,
+			UserCount: refCount,
+			DependsOn: deps,
+		}
+	}
+
+	return modules, nil
+}
+
+// ValidateUnloadSafety checks that each target module can be safely unloaded.
+// For each target, it reads /sys/module/<mod>/holders/ to get the actual kernel module
+// holders (modules that depend on this one), then compares the holder count against the
+// refcount from /proc/modules. If refcount > holder count, there are unknown userspace
+// processes holding the module and unloading would be unsafe.
+// sysModulePath should be "/sys/module" in production or a temp dir for testing.
+func ValidateUnloadSafety(targets []string, modules map[string]ModuleInfo, sysModulePath string) error {
+	for _, target := range targets {
+		target = strings.TrimSpace(target)
+		if target == "" {
+			continue
+		}
+
+		info, found := modules[target]
+		if !found {
+			// Module not loaded — safe to proceed (nothing to unload)
+			continue
+		}
+
+		// Read /sys/module/<target>/holders/ for actual kernel module users
+		holdersDir := filepath.Join(sysModulePath, target, "holders")
+		var holderNames []string
+		holderCount := 0
+		entries, err := os.ReadDir(holdersDir)
+		if err == nil {
+			for _, entry := range entries {
+				holderNames = append(holderNames, entry.Name())
+				holderCount++
+			}
+		}
+		// If the directory doesn't exist, holderCount stays 0
+
+		if info.UserCount > holderCount {
+			userspaceCount := info.UserCount - holderCount
+			errMsg := fmt.Sprintf(
+				"module %q has refcount %d but only %d kernel module holder(s)",
+				target, info.UserCount, holderCount)
+			if holderCount > 0 {
+				errMsg += fmt.Sprintf(" (kernel dependents: %v)", holderNames)
+			}
+			errMsg += fmt.Sprintf(
+				"; %d unknown userspace process(es) are using this module — unsafe to unload."+
+					" Hint: check 'lsof /dev/infiniband/*' or 'fuser /dev/infiniband/*'",
+				userspaceCount)
+			return fmt.Errorf("%s", errMsg)
+		}
+	}
+	return nil
+}
+
+// ResolveUnloadOrder returns a topological ordering (leaf-first) of the target modules
+// suitable for safe unloading. It repeatedly emits modules whose in-set user count is zero.
+func ResolveUnloadOrder(targets []string, modules map[string]ModuleInfo) ([]string, error) {
+	// Build the set of targets
+	targetSet := make(map[string]bool)
+	for _, t := range targets {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			targetSet[t] = true
+		}
+	}
+
+	// Compute in-set dependency counts: for each target, how many other targets depend on it
+	inSetUsers := make(map[string]int)
+	for t := range targetSet {
+		inSetUsers[t] = 0
+	}
+
+	// For each module in the target set, DependsOn lists modules that USE it (upward).
+	// If dep is in t's DependsOn, dep depends on t, meaning t must be unloaded AFTER dep.
+	// So t gets inSetUsers++ for each in-set module that uses it.
+	for t := range targetSet {
+		info, found := modules[t]
+		if !found {
+			continue
+		}
+		for _, dep := range info.DependsOn {
+			if targetSet[dep] {
+				inSetUsers[t]++
+			}
+		}
+	}
+
+	var order []string
+	remaining := make(map[string]bool)
+	for t := range targetSet {
+		remaining[t] = true
+	}
+
+	for len(remaining) > 0 {
+		var ready []string
+		for t := range remaining {
+			if inSetUsers[t] == 0 {
+				ready = append(ready, t)
+			}
+		}
+
+		if len(ready) == 0 {
+			var stuck []string
+			for t := range remaining {
+				stuck = append(stuck, t)
+			}
+			return nil, fmt.Errorf("circular dependency detected among modules: %v", stuck)
+		}
+
+		// Sort ready for deterministic output
+		sortStrings(ready)
+		for _, t := range ready {
+			order = append(order, t)
+			delete(remaining, t)
+
+			// When t is removed, decrement inSetUsers for modules whose DependsOn includes t.
+			// DependsOn lists upward users, so if m.DependsOn contains t, then t uses m,
+			// and removing t reduces m's in-set user count.
+			for m := range remaining {
+				info, found := modules[m]
+				if !found {
+					continue
+				}
+				for _, dep := range info.DependsOn {
+					if dep == t {
+						inSetUsers[m]--
+					}
+				}
+			}
+		}
+	}
+
+	return order, nil
+}
+
+// sortStrings sorts a slice of strings in place (simple insertion sort to avoid importing sort).
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}

--- a/entrypoint/internal/entrypoint/module_deps_test.go
+++ b/entrypoint/internal/entrypoint/module_deps_test.go
@@ -1,0 +1,246 @@
+/*
+ Copyright 2026, NVIDIA CORPORATION & AFFILIATES
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package entrypoint
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ModuleDeps", func() {
+	var tempDir string
+
+	BeforeEach(func() {
+		tempDir = GinkgoT().TempDir()
+	})
+
+	Context("ParseProcModules", func() {
+		It("should parse valid /proc/modules lines", func() {
+			content := `mlx5_core 1234567 2 mlx5_ib,mlx5_vdpa, Live 0xffffffffc0000000
+mlx5_ib 234567 1 rdma_cm, Live 0xffffffffc0100000
+ib_core 345678 3 mlx5_ib,rdma_cm,ib_umad, Live 0xffffffffc0200000
+nvidia_peermem 12345 0 - Live 0xffffffffc0300000
+`
+			procFile := filepath.Join(tempDir, "modules")
+			Expect(os.WriteFile(procFile, []byte(content), 0o644)).To(Succeed())
+
+			modules, err := ParseProcModules(procFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(modules).To(HaveLen(4))
+
+			Expect(modules["mlx5_core"].UserCount).To(Equal(2))
+			Expect(modules["mlx5_core"].DependsOn).To(ConsistOf("mlx5_ib", "mlx5_vdpa"))
+
+			Expect(modules["mlx5_ib"].UserCount).To(Equal(1))
+			Expect(modules["mlx5_ib"].DependsOn).To(ConsistOf("rdma_cm"))
+
+			Expect(modules["ib_core"].UserCount).To(Equal(3))
+			Expect(modules["ib_core"].DependsOn).To(ConsistOf("mlx5_ib", "rdma_cm", "ib_umad"))
+
+			Expect(modules["nvidia_peermem"].UserCount).To(Equal(0))
+			Expect(modules["nvidia_peermem"].DependsOn).To(BeEmpty())
+		})
+
+		It("should handle malformed lines gracefully", func() {
+			content := `valid_mod 1234 1 dep1, Live 0x0
+short_line 1234
+`
+			procFile := filepath.Join(tempDir, "modules")
+			Expect(os.WriteFile(procFile, []byte(content), 0o644)).To(Succeed())
+
+			modules, err := ParseProcModules(procFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(modules).To(HaveLen(1))
+			Expect(modules).To(HaveKey("valid_mod"))
+		})
+
+		It("should handle empty file", func() {
+			procFile := filepath.Join(tempDir, "modules")
+			Expect(os.WriteFile(procFile, []byte(""), 0o644)).To(Succeed())
+
+			modules, err := ParseProcModules(procFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(modules).To(BeEmpty())
+		})
+
+		It("should return error for non-existent file", func() {
+			_, err := ParseProcModules(filepath.Join(tempDir, "nonexistent"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("ValidateUnloadSafety", func() {
+		var sysModDir string
+
+		BeforeEach(func() {
+			sysModDir = filepath.Join(tempDir, "sys_module")
+			Expect(os.MkdirAll(sysModDir, 0o755)).To(Succeed())
+		})
+
+		// createHolders creates a /sys/module/<mod>/holders/ directory with the given holder entries.
+		createHolders := func(mod string, holders []string) {
+			holdersDir := filepath.Join(sysModDir, mod, "holders")
+			Expect(os.MkdirAll(holdersDir, 0o755)).To(Succeed())
+			for _, h := range holders {
+				// Create empty files to mimic sysfs holder entries
+				Expect(os.WriteFile(filepath.Join(holdersDir, h), []byte{}, 0o644)).To(Succeed())
+			}
+		}
+
+		It("should fail when refcount exceeds holder count — reporting userspace users and holder names", func() {
+			// refcount=2, 1 holder → 1 unknown userspace user
+			createHolders("ib_umad", []string{"mlx5_ib"})
+			modules := map[string]ModuleInfo{
+				"ib_umad": {Name: "ib_umad", UserCount: 2, DependsOn: []string{"ib_core"}},
+			}
+
+			err := ValidateUnloadSafety([]string{"ib_umad"}, modules, sysModDir)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("1 unknown userspace process"))
+			Expect(err.Error()).To(ContainSubstring("mlx5_ib"))
+			Expect(err.Error()).To(ContainSubstring("lsof /dev/infiniband/*"))
+		})
+
+		It("should pass when refcount matches holder count — all users accounted for", func() {
+			// refcount=1, 1 holder → passes (all accounted for)
+			createHolders("ib_umad", []string{"mlx5_ib"})
+			modules := map[string]ModuleInfo{
+				"ib_umad": {Name: "ib_umad", UserCount: 1, DependsOn: []string{"ib_core"}},
+			}
+
+			err := ValidateUnloadSafety([]string{"ib_umad"}, modules, sysModDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass when refcount is zero", func() {
+			createHolders("nvidia_peermem", nil)
+			modules := map[string]ModuleInfo{
+				"nvidia_peermem": {Name: "nvidia_peermem", UserCount: 0, DependsOn: nil},
+			}
+
+			err := ValidateUnloadSafety([]string{"nvidia_peermem"}, modules, sysModDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip modules that are not loaded", func() {
+			modules := map[string]ModuleInfo{}
+			err := ValidateUnloadSafety([]string{"not_loaded_mod"}, modules, sysModDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should treat missing holders dir as holderCount=0 and compare against refcount", func() {
+			// holders dir doesn't exist → holderCount=0
+			// refcount=1 → 1 unknown userspace user
+			modules := map[string]ModuleInfo{
+				"some_mod": {Name: "some_mod", UserCount: 1, DependsOn: nil},
+			}
+
+			err := ValidateUnloadSafety([]string{"some_mod"}, modules, sysModDir)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("1 unknown userspace process"))
+		})
+
+		It("should pass when holders dir does not exist and refcount is zero", func() {
+			modules := map[string]ModuleInfo{
+				"clean_mod": {Name: "clean_mod", UserCount: 0, DependsOn: nil},
+			}
+
+			err := ValidateUnloadSafety([]string{"clean_mod"}, modules, sysModDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass with empty targets", func() {
+			modules := map[string]ModuleInfo{
+				"lustre": {Name: "lustre", UserCount: 5, DependsOn: []string{"ib_core"}},
+			}
+			err := ValidateUnloadSafety([]string{}, modules, sysModDir)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("ResolveUnloadOrder", func() {
+		It("should resolve a linear chain", func() {
+			// lustre's DependsOn contains ko2iblnd (ko2iblnd uses lustre)
+			// So ko2iblnd should be unloaded first (leaf-first)
+			modules := map[string]ModuleInfo{
+				"lustre": {
+					Name:       "lustre",
+					UserCount:  1,
+					DependsOn: []string{"ko2iblnd"},
+				},
+				"ko2iblnd": {
+					Name:       "ko2iblnd",
+					UserCount:  0,
+					DependsOn: nil,
+				},
+			}
+
+			order, err := ResolveUnloadOrder([]string{"lustre", "ko2iblnd"}, modules)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(HaveLen(2))
+			// ko2iblnd should come before lustre (leaf-first)
+			Expect(order[0]).To(Equal("ko2iblnd"))
+			Expect(order[1]).To(Equal("lustre"))
+		})
+
+		It("should resolve a diamond dependency", func() {
+			// A is used by B and C; B and C are used by D
+			modules := map[string]ModuleInfo{
+				"A": {Name: "A", UserCount: 2, DependsOn: []string{"B", "C"}},
+				"B": {Name: "B", UserCount: 1, DependsOn: []string{"D"}},
+				"C": {Name: "C", UserCount: 1, DependsOn: []string{"D"}},
+				"D": {Name: "D", UserCount: 0, DependsOn: nil},
+			}
+
+			order, err := ResolveUnloadOrder([]string{"A", "B", "C", "D"}, modules)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(HaveLen(4))
+			// D must be first (leaf), A must be last
+			Expect(order[0]).To(Equal("D"))
+			Expect(order[3]).To(Equal("A"))
+		})
+
+		It("should handle a single module", func() {
+			modules := map[string]ModuleInfo{
+				"single": {Name: "single", UserCount: 0, DependsOn: nil},
+			}
+
+			order, err := ResolveUnloadOrder([]string{"single"}, modules)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(Equal([]string{"single"}))
+		})
+
+		It("should handle modules not in /proc/modules", func() {
+			modules := map[string]ModuleInfo{}
+			order, err := ResolveUnloadOrder([]string{"missing"}, modules)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(Equal([]string{"missing"}))
+		})
+
+		It("should handle empty targets", func() {
+			modules := map[string]ModuleInfo{
+				"something": {Name: "something", UserCount: 0, DependsOn: nil},
+			}
+			order, err := ResolveUnloadOrder([]string{}, modules)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(order).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
Boolean env var (default false) that, when true, blacklists and
injects all 23 known third-party RDMA kernel modules into openibd's
unload sequence. The module list is hardcoded from rdma-core
providers (bnxt_re, efa, qedr, siw, iw_cm, etc.) and follows the
same pattern as UNLOAD_STORAGE_MODULES.

Applied to both Go and bash entrypoints. Pre-flight safety
validation is handled exclusively by the network-operator init
container, which runs before this container starts.