### PR TITLE
Remove misclassified modules from ThirdPartyRDMAModules

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@
 : ${UNLOAD_THIRD_PARTY_RDMA_MODULES:=false}
 
 # Hardcoded list of known third-party RDMA modules (non-NVIDIA, from rdma-core)
-THIRD_PARTY_RDMA_MODULES="bnxt_re efa erdma iw_cxgb4 hfi1 hns_roce ionic_rdma irdma ib_qib mana_ib ocrdma qedr rdma_rxe siw vmw_pvrdma ib_srp ib_iser iw_cm ib_isert nvme_rdma nvmet_rdma rpcrdma xprtrdma"
+THIRD_PARTY_RDMA_MODULES="bnxt_re efa erdma iw_cxgb4 hfi1 hns_roce ionic_rdma irdma ib_qib mana_ib ocrdma qedr rdma_rxe siw vmw_pvrdma"
 
 : ${UBUNTU_PRO_TOKEN:=""}
 

--- a/entrypoint/internal/config/config.go
+++ b/entrypoint/internal/config/config.go
@@ -74,12 +74,14 @@ type Config struct {
 // ThirdPartyRDMAModules is the hardcoded list of known third-party RDMA kernel modules
 // (non-NVIDIA modules from the rdma-core ecosystem) that can block MOFED driver reload.
 // This list is used when UnloadThirdPartyRdmaModules is true.
+//
+// NOTE: Do NOT add core RDMA infrastructure modules (iw_cm, ib_cm, rdma_cm, etc.)
+// here — MOFED manages those in its own unload sequence. Do NOT add storage-over-RDMA
+// modules that are already handled by UNLOAD_STORAGE_MODULES (StorageModules).
 var ThirdPartyRDMAModules = []string{
 	"bnxt_re", "efa", "erdma", "iw_cxgb4", "hfi1", "hns_roce",
 	"ionic_rdma", "irdma", "ib_qib", "mana_ib", "ocrdma", "qedr",
 	"rdma_rxe", "siw", "vmw_pvrdma",
-	"ib_srp", "ib_iser", "iw_cm", "ib_isert",
-	"nvme_rdma", "nvmet_rdma", "rpcrdma", "xprtrdma",
 }
 
 // GetConfig parses environment variables and returns a Config struct.

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -3776,8 +3776,7 @@ var _ = Describe("Driver OFED Blacklist", func() {
 			// Verify a few representative third-party modules
 			Expect(contentStr).To(ContainSubstring("blacklist bnxt_re"))
 			Expect(contentStr).To(ContainSubstring("blacklist qedr"))
-			Expect(contentStr).To(ContainSubstring("blacklist nvme_rdma"))
-			Expect(contentStr).To(ContainSubstring("blacklist xprtrdma"))
+			Expect(contentStr).To(ContainSubstring("blacklist siw"))
 
 			// Count blacklist lines - should be 2 OFED + len(ThirdPartyRDMAModules)
 			lines := strings.Split(contentStr, "\n")


### PR DESCRIPTION
These modules were incorrectly placed in the third-party RDMA list, causing the container to fail on setups where they are loaded when UNLOAD_THIRD_PARTY_RDMA_MODULES is false (the default).

Removed core RDMA infrastructure module:
- iw_cm (iWARP Connection Manager): Part of the Linux kernel RDMA subsystem and shipped with MOFED. Loaded on virtually all RDMA-capable systems. MOFED already manages it in openibd.

Removed storage-over-RDMA modules (belong under UNLOAD_STORAGE_MODULES):
- ib_srp (SCSI RDMA Protocol initiator)
- ib_iser (iSCSI Extensions for RDMA initiator)
- ib_isert (iSER target) — was already in StorageModules
- nvme_rdma (NVMe over RDMA initiator) — was already in StorageModules
- nvmet_rdma (NVMe over RDMA target) — was already in StorageModules
- rpcrdma (NFS/RPC over RDMA) — was already in StorageModules
- xprtrdma (NFS/RPC transport over RDMA) — was already in StorageModules

The list now contains only genuine third-party NIC vendor RDMA provider modules (bnxt_re, efa, qedr, siw, etc.).

Fixes a regression from 65246ad where handleKernelModules() would find iw_cm loaded on normal RDMA setups and terminate with "third-party RDMA modules are loaded".