### PR TITLE
feat: Install NFS userspace tools on host when ENABLE_NFSRDMA is enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The following environment variables can be set at container runtime to control d
 | `OFED_BLACKLIST_MODULES` | `mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm` | Colon-separated list of OFED kernel modules to blacklist on the host. |
 | `UNLOAD_THIRD_PARTY_RDMA_MODULES` | `false` | When `true`, all known third-party RDMA kernel modules (from rdma-core: qedr, efa, siw, etc.) are blacklisted and unloaded before OFED driver reload. The module list is hardcoded. |
 | `UNLOAD_STORAGE_MODULES` | `false` | When `true`, storage modules (ib_isert, nvme_rdma, etc.) are unloaded during driver restart. |
+| `ENABLE_NFSRDMA` | `false` | When `true`, builds and loads NFS-RDMA kernel modules (rpcrdma, nvme_rdma) and copies NFS userspace tools (mount.nfs) to the host if not already present. |
 | `RESTORE_DRIVER_ON_POD_TERMINATION` | `false` | When `true`, restores the inbox driver on container teardown. |
 
 >[!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The following environment variables can be set at container runtime to control d
 | `MLX5_AUXILIARY_MODULES` | `mlx5_vdpa mlx5_fwctl mlx5_dpll` | Space-separated list of mlx5 auxiliary modules to temporarily blacklist and unload before driver restart, then explicitly reload after the new driver stack is active. Set to an empty string to disable this handling. |
 | `UNLOAD_THIRD_PARTY_RDMA_MODULES` | `false` | When `true`, all known third-party RDMA kernel modules (from rdma-core: qedr, efa, siw, etc.) are blacklisted and unloaded before OFED driver reload. The module list is hardcoded. |
 | `UNLOAD_STORAGE_MODULES` | `false` | When `true`, storage modules (ib_isert, nvme_rdma, etc.) are unloaded during driver restart. |
+| `ENABLE_NFSRDMA` | `false` | When `true`, builds and loads NFS-RDMA kernel modules (rpcrdma, nvme_rdma) and copies NFS userspace tools (mount.nfs) to the host if not already present. |
 | `RESTORE_DRIVER_ON_POD_TERMINATION` | `false` | When `true`, restores the inbox driver on container teardown. |
 
 >[!IMPORTANT]

--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -61,7 +61,9 @@ RUN set -x && \
     dnf -y update && \
     dnf -y install perl \
 # Container functional requirements
-    jq iproute kmod procps-ng udev && \
+    jq iproute kmod procps-ng udev \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-utils && \
 # DKMS and kernel module build tools when DKMS enabled
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         dnf -y install dkms gcc make bison flex elfutils-libelf-devel; \
@@ -189,7 +191,9 @@ RUN set -x && \
 # MOFED functional requirements
     dnf install -y pciutils hostname udev ethtool \
 # Container functional requirements
-    jq iproute kmod procps-ng udev && \
+    jq iproute kmod procps-ng udev \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-utils && \
 # DKMS and kernel module build tools when DKMS enabled (runtime dkms add/build/install)
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         MAJOR_VER=$(echo ${D_OS} | sed 's/rhel\([0-9]*\).*/\1/') && \

--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -71,7 +71,9 @@ RUN set -x && \
     dnf -y update --exclude=redhat-release --releasever=${RELEASE_VER} && \
     dnf -y install perl \
 # Container functional requirements
-    jq iproute kmod procps-ng udev --releasever=${RELEASE_VER}
+    jq iproute kmod procps-ng udev \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-utils --releasever=${RELEASE_VER}
 
 COPY --from=go_builder /workspace/build/entrypoint /root/entrypoint
 WORKDIR /root
@@ -204,7 +206,9 @@ RUN set -x && \
 # MOFED functional requirements
     dnf install -y pciutils hostname udev ethtool \
 # Container functional requirements
-    jq iproute kmod procps-ng udev --releasever=${RELEASE_VER} && \
+    jq iproute kmod procps-ng udev \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-utils --releasever=${RELEASE_VER} && \
 # DKMS and kernel module build tools when DKMS enabled (runtime dkms add/build/install)
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         MAJOR_VER=$(echo ${D_OS} | sed 's/rhel\([0-9]*\).*/\1/') && \

--- a/SLES_Dockerfile
+++ b/SLES_Dockerfile
@@ -53,7 +53,9 @@ RUN set -x && \
     perl pciutils kmod lsof python3 \
 # dh-python not found
 # Container functional requirements
-    jq iproute2 udev ethtool awk procps
+    jq iproute2 udev ethtool awk procps \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-client
 
 COPY --from=go_builder /workspace/build/entrypoint /root/entrypoint
 WORKDIR /root

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -56,7 +56,9 @@ RUN set -x && \
 # Driver build / install script requirements
     perl pciutils kmod lsof python3 dh-python \
 # Container functional requirements
-    jq iproute2 udev ethtool ca-certificates && \
+    jq iproute2 udev ethtool ca-certificates \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-common && \
 # DKMS and kernel module build tools (always installed for driver build/install)
     DEBIAN_FRONTEND=noninteractive apt-get -yq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install dkms build-essential bison flex libelf-dev
 

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -55,7 +55,9 @@ RUN set -x && \
 # Driver build / install script requirements
     perl pciutils kmod lsof python3 dh-python \
 # Container functional requirements
-    jq iproute2 udev ethtool ca-certificates
+    jq iproute2 udev ethtool ca-certificates \
+# NFS userspace tools (mount.nfs) — copied to host at runtime when ENABLE_NFSRDMA=true
+    nfs-common
 
 COPY --from=go_builder /workspace/build/entrypoint /root/entrypoint
 ADD ./entrypoint.sh /root/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1140,6 +1140,37 @@ function load_nfsrdma() {
     fi
 }
 
+function install_nfs_userspace() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    if [[ "${ENABLE_NFSRDMA}" != true ]]; then
+        return 0
+    fi
+
+    # Check if mount.nfs already exists on the host
+    if [[ -f /host/usr/sbin/mount.nfs ]]; then
+        timestamp_print "NFS userspace tools already present on host"
+        return 0
+    fi
+
+    timestamp_print "Installing NFS userspace tools (mount.nfs) to host"
+
+    # Copy mount.nfs and mount.nfs4 binaries from container to host
+    local nfs_bins="mount.nfs mount.nfs4 umount.nfs umount.nfs4"
+    for bin in ${nfs_bins}; do
+        local src=""
+        if [[ -f /usr/sbin/${bin} ]]; then
+            src="/usr/sbin/${bin}"
+        elif [[ -f /sbin/${bin} ]]; then
+            src="/sbin/${bin}"
+        fi
+        if [[ -n "${src}" ]]; then
+            exec_cmd "cp ${src} /host/usr/sbin/${bin}"
+            timestamp_print "Copied ${bin} to /host/usr/sbin/"
+        fi
+    done
+}
+
 # function check_loaded_kmod_srcver_vs_modinfo() returns 0 if all provided modules
 # srcversion from sysfs match information from modinfo
 function check_loaded_kmod_srcver_vs_modinfo() {
@@ -1731,6 +1762,8 @@ if ! ${build_precompiled}; then
 fi
 
 load_driver
+
+install_nfs_userspace
 
 ${reuse_driver_inventory} && cleanup_driver_inventory
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1147,17 +1147,16 @@ function install_nfs_userspace() {
         return 0
     fi
 
-    # Check if mount.nfs already exists on the host
-    if [[ -f /host/usr/sbin/mount.nfs ]]; then
-        timestamp_print "NFS userspace tools already present on host"
-        return 0
-    fi
+    timestamp_print "Installing NFS userspace tools to host"
 
-    timestamp_print "Installing NFS userspace tools (mount.nfs) to host"
-
-    # Copy mount.nfs and mount.nfs4 binaries from container to host
+    # Copy mount.nfs and related binaries from container to host
     local nfs_bins="mount.nfs mount.nfs4 umount.nfs umount.nfs4"
     for bin in ${nfs_bins}; do
+        # Skip if already present on host
+        if [[ -f /host/usr/sbin/${bin} ]]; then
+            debug_print "${bin} already present on host, skipping"
+            continue
+        fi
         local src=""
         if [[ -f /usr/sbin/${bin} ]]; then
             src="/usr/sbin/${bin}"
@@ -1165,8 +1164,11 @@ function install_nfs_userspace() {
             src="/sbin/${bin}"
         fi
         if [[ -n "${src}" ]]; then
-            exec_cmd "cp ${src} /host/usr/sbin/${bin}"
-            timestamp_print "Copied ${bin} to /host/usr/sbin/"
+            if cp "${src}" "/host/usr/sbin/${bin}"; then
+                timestamp_print "Copied ${bin} to /host/usr/sbin/"
+            else
+                timestamp_print "WARNING: Failed to copy ${bin} to /host/usr/sbin/, skipping"
+            fi
         fi
     done
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1289,17 +1289,16 @@ function install_nfs_userspace() {
         return 0
     fi
 
-    # Check if mount.nfs already exists on the host
-    if [[ -f /host/usr/sbin/mount.nfs ]]; then
-        timestamp_print "NFS userspace tools already present on host"
-        return 0
-    fi
+    timestamp_print "Installing NFS userspace tools to host"
 
-    timestamp_print "Installing NFS userspace tools (mount.nfs) to host"
-
-    # Copy mount.nfs and mount.nfs4 binaries from container to host
+    # Copy mount.nfs and related binaries from container to host
     local nfs_bins="mount.nfs mount.nfs4 umount.nfs umount.nfs4"
     for bin in ${nfs_bins}; do
+        # Skip if already present on host
+        if [[ -f /host/usr/sbin/${bin} ]]; then
+            debug_print "${bin} already present on host, skipping"
+            continue
+        fi
         local src=""
         if [[ -f /usr/sbin/${bin} ]]; then
             src="/usr/sbin/${bin}"
@@ -1307,8 +1306,11 @@ function install_nfs_userspace() {
             src="/sbin/${bin}"
         fi
         if [[ -n "${src}" ]]; then
-            exec_cmd "cp ${src} /host/usr/sbin/${bin}"
-            timestamp_print "Copied ${bin} to /host/usr/sbin/"
+            if cp "${src}" "/host/usr/sbin/${bin}"; then
+                timestamp_print "Copied ${bin} to /host/usr/sbin/"
+            else
+                timestamp_print "WARNING: Failed to copy ${bin} to /host/usr/sbin/, skipping"
+            fi
         fi
     done
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1282,6 +1282,37 @@ function load_nfsrdma() {
     fi
 }
 
+function install_nfs_userspace() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    if [[ "${ENABLE_NFSRDMA}" != true ]]; then
+        return 0
+    fi
+
+    # Check if mount.nfs already exists on the host
+    if [[ -f /host/usr/sbin/mount.nfs ]]; then
+        timestamp_print "NFS userspace tools already present on host"
+        return 0
+    fi
+
+    timestamp_print "Installing NFS userspace tools (mount.nfs) to host"
+
+    # Copy mount.nfs and mount.nfs4 binaries from container to host
+    local nfs_bins="mount.nfs mount.nfs4 umount.nfs umount.nfs4"
+    for bin in ${nfs_bins}; do
+        local src=""
+        if [[ -f /usr/sbin/${bin} ]]; then
+            src="/usr/sbin/${bin}"
+        elif [[ -f /sbin/${bin} ]]; then
+            src="/sbin/${bin}"
+        fi
+        if [[ -n "${src}" ]]; then
+            exec_cmd "cp ${src} /host/usr/sbin/${bin}"
+            timestamp_print "Copied ${bin} to /host/usr/sbin/"
+        fi
+    done
+}
+
 # function check_loaded_kmod_srcver_vs_modinfo() returns 0 if all provided modules
 # srcversion from sysfs match information from modinfo
 function check_loaded_kmod_srcver_vs_modinfo() {
@@ -2038,6 +2069,8 @@ if ! ${build_precompiled}; then
 fi
 
 load_driver
+
+install_nfs_userspace
 
 ${reuse_driver_inventory} && cleanup_driver_inventory
 

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -1766,16 +1766,17 @@ func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
 		return nil
 	}
 
-	// Check if mount.nfs already exists on host
-	if _, err := d.os.Stat("/host/usr/sbin/mount.nfs"); err == nil {
-		log.Info("NFS userspace tools already present on host")
-		return nil
-	}
-
-	log.Info("Installing NFS userspace tools (mount.nfs) to host")
+	log.Info("Installing NFS userspace tools to host")
 
 	nfsBins := []string{"mount.nfs", "mount.nfs4", "umount.nfs", "umount.nfs4"}
 	for _, bin := range nfsBins {
+		// Skip if already present on host
+		dst := "/host/usr/sbin/" + bin
+		if _, err := d.os.Stat(dst); err == nil {
+			log.V(1).Info("NFS binary already present on host, skipping", "binary", bin)
+			continue
+		}
+
 		src := ""
 		if _, err := d.os.Stat("/usr/sbin/" + bin); err == nil {
 			src = "/usr/sbin/" + bin
@@ -1786,10 +1787,10 @@ func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
 			log.V(1).Info("NFS binary not found in container, skipping", "binary", bin)
 			continue
 		}
-		dst := "/host/usr/sbin/" + bin
 		_, _, err := d.cmd.RunCommand(ctx, "cp", src, dst)
 		if err != nil {
-			return fmt.Errorf("failed to copy %s to host: %w", bin, err)
+			log.V(1).Info("WARNING: failed to copy NFS binary to host, skipping", "binary", bin, "error", err)
+			continue
 		}
 		log.Info("Copied NFS binary to host", "binary", bin, "destination", dst)
 	}

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -310,6 +310,14 @@ func (d *driverMgr) Load(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to mount rootfs: %w", err)
 	}
 
+	// Install NFS userspace tools on host if NFSRDMA is enabled
+	if d.cfg.EnableNfsRdma {
+		if err := d.installNfsUserspace(ctx); err != nil {
+			log.V(1).Info("Failed to install NFS userspace tools on host", "error", err)
+			// Non-fatal error, continue
+		}
+	}
+
 	// Clean up old driver inventory to free disk space
 	if err := d.cleanupDriverInventory(ctx); err != nil {
 		log.V(1).Info("Failed to cleanup driver inventory", "error", err)
@@ -1743,6 +1751,47 @@ func (d *driverMgr) loadNfsRdma(ctx context.Context) error {
 	_, _, err := d.cmd.RunCommand(ctx, "modprobe", "rpcrdma")
 	if err != nil {
 		return fmt.Errorf("failed to load rpcrdma module: %w", err)
+	}
+
+	return nil
+}
+
+// installNfsUserspace copies NFS userspace tools (mount.nfs) from the container
+// to the host filesystem when ENABLE_NFSRDMA is true. This ensures the host has
+// the mount.nfs binary required for NFS mounts over RDMA.
+func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	if !d.cfg.EnableNfsRdma {
+		return nil
+	}
+
+	// Check if mount.nfs already exists on host
+	if _, err := d.os.Stat("/host/usr/sbin/mount.nfs"); err == nil {
+		log.Info("NFS userspace tools already present on host")
+		return nil
+	}
+
+	log.Info("Installing NFS userspace tools (mount.nfs) to host")
+
+	nfsBins := []string{"mount.nfs", "mount.nfs4", "umount.nfs", "umount.nfs4"}
+	for _, bin := range nfsBins {
+		src := ""
+		if _, err := d.os.Stat("/usr/sbin/" + bin); err == nil {
+			src = "/usr/sbin/" + bin
+		} else if _, err := d.os.Stat("/sbin/" + bin); err == nil {
+			src = "/sbin/" + bin
+		}
+		if src == "" {
+			log.V(1).Info("NFS binary not found in container, skipping", "binary", bin)
+			continue
+		}
+		dst := "/host/usr/sbin/" + bin
+		_, _, err := d.cmd.RunCommand(ctx, "cp", src, dst)
+		if err != nil {
+			return fmt.Errorf("failed to copy %s to host: %w", bin, err)
+		}
+		log.Info("Copied NFS binary to host", "binary", bin, "destination", dst)
 	}
 
 	return nil

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -339,6 +339,14 @@ func (d *driverMgr) Load(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to mount rootfs: %w", err)
 	}
 
+	// Install NFS userspace tools on host if NFSRDMA is enabled
+	if d.cfg.EnableNfsRdma {
+		if err := d.installNfsUserspace(ctx); err != nil {
+			log.V(1).Info("Failed to install NFS userspace tools on host", "error", err)
+			// Non-fatal error, continue
+		}
+	}
+
 	// Clean up old driver inventory to free disk space
 	if err := d.cleanupDriverInventory(ctx); err != nil {
 		log.V(1).Info("Failed to cleanup driver inventory", "error", err)
@@ -2067,6 +2075,47 @@ func (d *driverMgr) loadNfsRdma(ctx context.Context) error {
 	_, _, err := d.cmd.RunCommand(ctx, "modprobe", "rpcrdma")
 	if err != nil {
 		return fmt.Errorf("failed to load rpcrdma module: %w", err)
+	}
+
+	return nil
+}
+
+// installNfsUserspace copies NFS userspace tools (mount.nfs) from the container
+// to the host filesystem when ENABLE_NFSRDMA is true. This ensures the host has
+// the mount.nfs binary required for NFS mounts over RDMA.
+func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	if !d.cfg.EnableNfsRdma {
+		return nil
+	}
+
+	// Check if mount.nfs already exists on host
+	if _, err := d.os.Stat("/host/usr/sbin/mount.nfs"); err == nil {
+		log.Info("NFS userspace tools already present on host")
+		return nil
+	}
+
+	log.Info("Installing NFS userspace tools (mount.nfs) to host")
+
+	nfsBins := []string{"mount.nfs", "mount.nfs4", "umount.nfs", "umount.nfs4"}
+	for _, bin := range nfsBins {
+		src := ""
+		if _, err := d.os.Stat("/usr/sbin/" + bin); err == nil {
+			src = "/usr/sbin/" + bin
+		} else if _, err := d.os.Stat("/sbin/" + bin); err == nil {
+			src = "/sbin/" + bin
+		}
+		if src == "" {
+			log.V(1).Info("NFS binary not found in container, skipping", "binary", bin)
+			continue
+		}
+		dst := "/host/usr/sbin/" + bin
+		_, _, err := d.cmd.RunCommand(ctx, "cp", src, dst)
+		if err != nil {
+			return fmt.Errorf("failed to copy %s to host: %w", bin, err)
+		}
+		log.Info("Copied NFS binary to host", "binary", bin, "destination", dst)
 	}
 
 	return nil

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -339,12 +339,10 @@ func (d *driverMgr) Load(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("failed to mount rootfs: %w", err)
 	}
 
-	// Install NFS userspace tools on host if NFSRDMA is enabled
+	// Install NFS userspace tools on host if NFSRDMA is enabled.
+	// Failures are logged inside and are non-fatal.
 	if d.cfg.EnableNfsRdma {
-		if err := d.installNfsUserspace(ctx); err != nil {
-			log.V(1).Info("Failed to install NFS userspace tools on host", "error", err)
-			// Non-fatal error, continue
-		}
+		d.installNfsUserspace(ctx)
 	}
 
 	// Clean up old driver inventory to free disk space
@@ -2083,23 +2081,25 @@ func (d *driverMgr) loadNfsRdma(ctx context.Context) error {
 // installNfsUserspace copies NFS userspace tools (mount.nfs) from the container
 // to the host filesystem when ENABLE_NFSRDMA is true. This ensures the host has
 // the mount.nfs binary required for NFS mounts over RDMA.
-func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
+// All failures are non-fatal: missing or uncopyable binaries are logged and skipped.
+func (d *driverMgr) installNfsUserspace(ctx context.Context) {
 	log := logr.FromContextOrDiscard(ctx)
 
 	if !d.cfg.EnableNfsRdma {
-		return nil
+		return
 	}
 
-	// Check if mount.nfs already exists on host
-	if _, err := d.os.Stat("/host/usr/sbin/mount.nfs"); err == nil {
-		log.Info("NFS userspace tools already present on host")
-		return nil
-	}
-
-	log.Info("Installing NFS userspace tools (mount.nfs) to host")
+	log.Info("Installing NFS userspace tools to host")
 
 	nfsBins := []string{"mount.nfs", "mount.nfs4", "umount.nfs", "umount.nfs4"}
 	for _, bin := range nfsBins {
+		// Skip if already present on host
+		dst := "/host/usr/sbin/" + bin
+		if _, err := d.os.Stat(dst); err == nil {
+			log.V(1).Info("NFS binary already present on host, skipping", "binary", bin)
+			continue
+		}
+
 		src := ""
 		if _, err := d.os.Stat("/usr/sbin/" + bin); err == nil {
 			src = "/usr/sbin/" + bin
@@ -2110,15 +2110,13 @@ func (d *driverMgr) installNfsUserspace(ctx context.Context) error {
 			log.V(1).Info("NFS binary not found in container, skipping", "binary", bin)
 			continue
 		}
-		dst := "/host/usr/sbin/" + bin
 		_, _, err := d.cmd.RunCommand(ctx, "cp", src, dst)
 		if err != nil {
-			return fmt.Errorf("failed to copy %s to host: %w", bin, err)
+			log.V(1).Info("WARNING: failed to copy NFS binary to host, skipping", "binary", bin, "error", err)
+			continue
 		}
 		log.Info("Copied NFS binary to host", "binary", bin, "destination", dst)
 	}
-
-	return nil
 }
 
 // printLoadedDriverVersion prints the currently loaded driver version

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -2309,6 +2309,97 @@ var _ = Describe("Driver", func() {
 		})
 	})
 
+	Context("installNfsUserspace", func() {
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+		})
+
+		It("should skip when NFSRDMA is disabled", func() {
+			cfg.EnableNfsRdma = false
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when mount.nfs already exists on host", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs already exists on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should copy NFS binaries from /usr/sbin/ to host", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// All binaries found in /usr/sbin/
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, nil)
+
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs4", "/host/usr/sbin/mount.nfs4").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs4", "/host/usr/sbin/umount.nfs4").Return("", "", nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fallback to /sbin/ when /usr/sbin/ binary not found", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// mount.nfs not in /usr/sbin/ but in /sbin/
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/mount.nfs").Return(nil, nil)
+			// mount.nfs4 not found anywhere
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			// umount.nfs in /usr/sbin/
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			// umount.nfs4 not found anywhere
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
+
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error when cp fails", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// Binary found
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+
+			// cp fails
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", errors.New("permission denied"))
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to copy mount.nfs to host"))
+		})
+	})
+
 	Context("printLoadedDriverVersion", func() {
 		BeforeEach(func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -2322,12 +2322,15 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should skip when mount.nfs already exists on host", func() {
+		It("should skip binaries already present on host", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs already exists on host
+			// All binaries already exist on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, nil)
 
 			err := dm.installNfsUserspace(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2337,8 +2340,11 @@ var _ = Describe("Driver", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries exist on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
 			// All binaries found in /usr/sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
@@ -2359,8 +2365,11 @@ var _ = Describe("Driver", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
 			// mount.nfs not in /usr/sbin/ but in /sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
@@ -2381,22 +2390,31 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return error when cp fails", func() {
+		It("should continue when cp fails for a binary", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
-			// Binary found
+			// All binaries found in /usr/sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, nil)
 
-			// cp fails
+			// cp fails for mount.nfs but succeeds for others
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", errors.New("permission denied"))
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs4", "/host/usr/sbin/mount.nfs4").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs4", "/host/usr/sbin/umount.nfs4").Return("", "", nil)
 
+			// Should not return error — cp failure is non-fatal
 			err := dm.installNfsUserspace(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to copy mount.nfs to host"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -2730,6 +2730,97 @@ var _ = Describe("Driver", func() {
 		})
 	})
 
+	Context("installNfsUserspace", func() {
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+		})
+
+		It("should skip when NFSRDMA is disabled", func() {
+			cfg.EnableNfsRdma = false
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when mount.nfs already exists on host", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs already exists on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should copy NFS binaries from /usr/sbin/ to host", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// All binaries found in /usr/sbin/
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, nil)
+
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs4", "/host/usr/sbin/mount.nfs4").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs4", "/host/usr/sbin/umount.nfs4").Return("", "", nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fallback to /sbin/ when /usr/sbin/ binary not found", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// mount.nfs not in /usr/sbin/ but in /sbin/
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/mount.nfs").Return(nil, nil)
+			// mount.nfs4 not found anywhere
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			// umount.nfs in /usr/sbin/
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			// umount.nfs4 not found anywhere
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
+
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return error when cp fails", func() {
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			// mount.nfs does not exist on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+
+			// Binary found
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+
+			// cp fails
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", errors.New("permission denied"))
+
+			err := dm.installNfsUserspace(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to copy mount.nfs to host"))
+		})
+	})
+
 	Context("printLoadedDriverVersion", func() {
 		BeforeEach(func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -2221,6 +2221,12 @@ var _ = Describe("Driver", func() {
 			// Mock loadNfsRdma
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "rpcrdma").Return("", "", nil)
 
+			// Mock installNfsUserspace - all binaries already present on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, nil)
+
 			// Mock printLoadedDriverVersion
 			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
 				"mlx5_core": {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
@@ -2333,6 +2339,12 @@ var _ = Describe("Driver", func() {
 
 			// Mock loadNfsRdma failure (should not cause Load to fail)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "rpcrdma").Return("", "", errors.New("rpcrdma load failed"))
+
+			// Mock installNfsUserspace - all binaries already present on host
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, nil)
 
 			// Mock printLoadedDriverVersion
 			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
@@ -2739,27 +2751,31 @@ var _ = Describe("Driver", func() {
 			cfg.EnableNfsRdma = false
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			err := dm.installNfsUserspace(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			dm.installNfsUserspace(ctx)
 		})
 
-		It("should skip when mount.nfs already exists on host", func() {
+		It("should skip binaries already present on host", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs already exists on host
+			// All binaries already exist on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, nil)
 
-			err := dm.installNfsUserspace(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			dm.installNfsUserspace(ctx)
 		})
 
 		It("should copy NFS binaries from /usr/sbin/ to host", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries exist on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
 			// All binaries found in /usr/sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
@@ -2772,16 +2788,18 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs4", "/host/usr/sbin/umount.nfs4").Return("", "", nil)
 
-			err := dm.installNfsUserspace(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			dm.installNfsUserspace(ctx)
 		})
 
 		It("should fallback to /sbin/ when /usr/sbin/ binary not found", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
 			// mount.nfs not in /usr/sbin/ but in /sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
@@ -2798,26 +2816,33 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
 
-			err := dm.installNfsUserspace(ctx)
-			Expect(err).NotTo(HaveOccurred())
+			dm.installNfsUserspace(ctx)
 		})
 
-		It("should return error when cp fails", func() {
+		It("should continue when cp fails for a binary", func() {
 			cfg.EnableNfsRdma = true
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 
-			// mount.nfs does not exist on host
+			// No binaries on host
 			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/mount.nfs4").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/usr/sbin/umount.nfs4").Return(nil, os.ErrNotExist)
 
-			// Binary found
+			// All binaries found in /usr/sbin/
 			osMock.EXPECT().Stat("/usr/sbin/mount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/mount.nfs4").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs").Return(nil, nil)
+			osMock.EXPECT().Stat("/usr/sbin/umount.nfs4").Return(nil, nil)
 
-			// cp fails
+			// cp fails for mount.nfs but succeeds for others
 			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs", "/host/usr/sbin/mount.nfs").Return("", "", errors.New("permission denied"))
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/mount.nfs4", "/host/usr/sbin/mount.nfs4").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs", "/host/usr/sbin/umount.nfs").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "/usr/sbin/umount.nfs4", "/host/usr/sbin/umount.nfs4").Return("", "", nil)
 
-			err := dm.installNfsUserspace(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to copy mount.nfs to host"))
+			// cp failure is non-fatal and must not panic
+			dm.installNfsUserspace(ctx)
 		})
 	})
 


### PR DESCRIPTION
Fixes: https://github.com/Mellanox/network-operator/issues/1876

Currently ENABLE_NFSRDMA builds and loads kernel modules (rpcrdma, nvme_rdma) but the host still needs mount.nfs to actually mount NFS shares over RDMA. Without it users have to manually install nfs-common/nfs-utils on every node. 