### PR TITLE
fix: invalidate driver cache on config changes

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1219,6 +1219,15 @@ function calculate_driver_inventory_md5_checksum() {
     find "${driver_inventory_path}" -type f -exec md5sum {} + | md5sum | awk '{ print $1 }'
 }
 
+# Returns a canonical string of the build-affecting configuration.
+# Used to detect config drift that requires a cache rebuild even when the kernel
+# and driver versions are unchanged (e.g. ENABLE_NFSRDMA toggled).
+function calculate_build_config_fingerprint() {
+    echo "ENABLE_NFSRDMA=${ENABLE_NFSRDMA}
+USE_DKMS=${USE_DKMS}
+APPEND_DRIVER_BUILD_FLAGS=${APPEND_DRIVER_BUILD_FLAGS}"
+}
+
 function build_driver() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -1227,6 +1236,7 @@ function build_driver() {
     if ${reuse_driver_inventory}; then
         driver_inventory_path="${NVIDIA_NIC_DRIVERS_INVENTORY_PATH}/${FULL_KVER}/${NVIDIA_NIC_DRIVER_VER}"
         checksum_path="${NVIDIA_NIC_DRIVERS_INVENTORY_PATH}/${FULL_KVER}/${NVIDIA_NIC_DRIVER_VER}.checksum"
+        buildconfig_path="${NVIDIA_NIC_DRIVERS_INVENTORY_PATH}/${FULL_KVER}/${NVIDIA_NIC_DRIVER_VER}.buildconfig"
 
         if [ -d "${driver_inventory_path}" ]; then
             if [ -f "${checksum_path}" ]; then
@@ -1234,19 +1244,33 @@ function build_driver() {
                 current_checksum=$(calculate_driver_inventory_md5_checksum)
 
                 if [ "${stored_checksum}" == "${current_checksum}" ]; then
-                    timestamp_print "Skipping driver build, reusing previously built packages for kernel ${FULL_KVER}"
-                    # When DKMS is enabled, kernel headers are still needed for dkms build
-                    if [[ "${USE_DKMS}" = true ]] && ${build_src}; then
-                        timestamp_print "Installing kernel prerequisites for DKMS"
-                        if ${IS_OS_UBUNTU}; then
-                            ubuntu_install_prerequisites
-                        elif ${IS_OS_SLES}; then
-                            sles_install_prerequisites
+                    # Package checksums match; also verify the build config fingerprint to detect
+                    # configuration drift (e.g. ENABLE_NFSRDMA toggled) that requires a rebuild
+                    # even though the cached packages are intact.
+                    if [ ! -f "${buildconfig_path}" ]; then
+                        timestamp_print "No build config fingerprint found for existing artifacts, building the driver again"
+                    else
+                        stored_buildconfig=$(cat "${buildconfig_path}")
+                        current_buildconfig=$(calculate_build_config_fingerprint)
+
+                        if [ "${stored_buildconfig}" != "${current_buildconfig}" ]; then
+                            timestamp_print "Build config has changed since last build, invalidating cache and rebuilding"
                         else
-                            redhat_install_prerequisites
+                            timestamp_print "Skipping driver build, reusing previously built packages for kernel ${FULL_KVER}"
+                            # When DKMS is enabled, kernel headers are still needed for dkms build
+                            if [[ "${USE_DKMS}" = true ]] && ${build_src}; then
+                                timestamp_print "Installing kernel prerequisites for DKMS"
+                                if ${IS_OS_UBUNTU}; then
+                                    ubuntu_install_prerequisites
+                                elif ${IS_OS_SLES}; then
+                                    sles_install_prerequisites
+                                else
+                                    redhat_install_prerequisites
+                                fi
+                            fi
+                            return 0
                         fi
                     fi
-                    return 0
                 else
                     timestamp_print "Check sum of the existing artifacts does not match, building the driver again"
                 fi
@@ -1315,6 +1339,10 @@ function build_driver() {
         current_checksum=$(calculate_driver_inventory_md5_checksum)
         timestamp_print "Storing the check sum for build artifacts at ${checksum_path}, check sum: ${current_checksum}"
         echo ${current_checksum} > "${checksum_path}"
+
+        current_buildconfig=$(calculate_build_config_fingerprint)
+        timestamp_print "Storing build config fingerprint at ${buildconfig_path}"
+        echo "${current_buildconfig}" > "${buildconfig_path}"
     fi
 
     driver_build_incomplete=false
@@ -1338,7 +1366,7 @@ function cleanup_driver_inventory() {
         for driver_ver_item in ${driver_ver_items}; do
             found_driver_ver_items=$((${found_driver_ver_items}+1))
 
-            if [[ ${driver_ver_item} != "${NVIDIA_NIC_DRIVER_VER}" && ${driver_ver_item} != "${NVIDIA_NIC_DRIVER_VER}.checksum" ]]; then
+            if [[ ${driver_ver_item} != "${NVIDIA_NIC_DRIVER_VER}" && ${driver_ver_item} != "${NVIDIA_NIC_DRIVER_VER}.checksum" && ${driver_ver_item} != "${NVIDIA_NIC_DRIVER_VER}.buildconfig" ]]; then
                 exec_cmd "rm -rf ${NVIDIA_NIC_DRIVERS_INVENTORY_PATH}/${kernel_ver_dir}/${driver_ver_item}"
                 removed_driver_ver_items=$((${removed_driver_ver_items}+1))
             fi

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -159,12 +159,15 @@ func (d *driverMgr) Build(ctx context.Context) error {
 		return fmt.Errorf("failed to get OS type: %w", err)
 	}
 
-	// Install OS-specific prerequisites (e.g. kernel headers).
-	// This must happen before the cache check because even when driver packages
-	// are cached, DKMS still needs kernel headers to build modules at runtime.
-	log.V(1).Info("About to install prerequisites", "os", osType, "kernel", kernelVersion)
-	if err := d.installPrerequisitesForOS(ctx, osType, kernelVersion); err != nil {
-		return fmt.Errorf("failed to install prerequisites: %w", err)
+	// For DTK builds the DTK sidecar handles compilation, so kernel headers are not
+	// needed in this container and package repos may not be reachable from it.
+	// For non-DTK builds, prerequisites must be installed before the cache check
+	// because DKMS still needs kernel headers even when driver packages are cached.
+	if !d.cfg.DtkOcpDriverBuild {
+		log.V(1).Info("About to install prerequisites", "os", osType, "kernel", kernelVersion)
+		if err := d.installPrerequisitesForOS(ctx, osType, kernelVersion); err != nil {
+			return fmt.Errorf("failed to install prerequisites: %w", err)
+		}
 	}
 
 	// Check driver inventory and validate checksums

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -542,8 +542,10 @@ func (d *driverMgr) cleanupDriverInventory(ctx context.Context) error {
 			foundItems++
 			driverVerItem := driverVerEntry.Name()
 
-			// Keep the current driver version and its checksum file
-			if driverVerItem == d.cfg.NvidiaNicDriverVer || driverVerItem == d.cfg.NvidiaNicDriverVer+".checksum" {
+			// Keep the current driver version directory, its checksum, and its build config fingerprint
+			if driverVerItem == d.cfg.NvidiaNicDriverVer ||
+				driverVerItem == d.cfg.NvidiaNicDriverVer+".checksum" ||
+				driverVerItem == d.cfg.NvidiaNicDriverVer+".buildconfig" {
 				continue
 			}
 
@@ -845,6 +847,14 @@ func (d *driverMgr) removeOfedModulesBlacklist(ctx context.Context) error {
 	return nil
 }
 
+// currentBuildConfigFingerprint returns a canonical string representing the build-affecting
+// configuration. If any of these values change between builds, the cached inventory must be
+// discarded so that the driver is rebuilt with the new flags.
+func (d *driverMgr) currentBuildConfigFingerprint() string {
+	return fmt.Sprintf("ENABLE_NFSRDMA=%v\nUSE_DKMS=%v\nAPPEND_DRIVER_BUILD_FLAGS=%s",
+		d.cfg.EnableNfsRdma, d.cfg.UseDKMS, d.cfg.AppendDriverBuildFlags)
+}
+
 // checkDriverInventory checks if driver inventory exists and validates checksums
 func (d *driverMgr) checkDriverInventory(ctx context.Context, kernelVersion string) (bool, string, error) {
 	log := logr.FromContextOrDiscard(ctx)
@@ -858,6 +868,7 @@ func (d *driverMgr) checkDriverInventory(ctx context.Context, kernelVersion stri
 	// Check if inventory directory exists
 	inventoryPath := filepath.Join(d.cfg.NvidiaNicDriversInventoryPath, kernelVersion, d.cfg.NvidiaNicDriverVer)
 	checksumPath := filepath.Join(d.cfg.NvidiaNicDriversInventoryPath, kernelVersion, d.cfg.NvidiaNicDriverVer+".checksum")
+	buildConfigPath := filepath.Join(d.cfg.NvidiaNicDriversInventoryPath, kernelVersion, d.cfg.NvidiaNicDriverVer+".buildconfig")
 
 	// Check if inventory directory exists
 	if _, err := d.os.Stat(inventoryPath); os.IsNotExist(err) {
@@ -889,14 +900,42 @@ func (d *driverMgr) checkDriverInventory(ctx context.Context, kernelVersion stri
 		return true, inventoryPath, nil
 	}
 
-	// Compare checksums
-	if strings.TrimSpace(string(storedChecksum)) == currentChecksum {
-		log.V(1).Info("Checksums match, skipping build", "checksum", currentChecksum)
-		return false, inventoryPath, nil
+	// Compare package checksums
+	if strings.TrimSpace(string(storedChecksum)) != currentChecksum {
+		log.V(1).Info("Checksums do not match, will rebuild", "stored", strings.TrimSpace(string(storedChecksum)), "current", currentChecksum)
+		return true, inventoryPath, nil
 	}
 
-	log.V(1).Info("Checksums do not match, will rebuild", "stored", strings.TrimSpace(string(storedChecksum)), "current", currentChecksum)
-	return true, inventoryPath, nil
+	// Package checksums match; now verify the build config fingerprint to detect
+	// configuration drift (e.g. ENABLE_NFSRDMA toggled) that requires a rebuild
+	// even though the cached packages are intact.
+	if _, err := d.os.Stat(buildConfigPath); os.IsNotExist(err) {
+		// No .buildconfig file means the cache was created by an older version of
+		// this entrypoint that did not record build flags. Treat as a cache miss so
+		// that the driver is rebuilt with the current, known-correct flags.
+		log.V(1).Info("No build config fingerprint found, will rebuild to ensure config correctness",
+			"path", buildConfigPath)
+		return true, inventoryPath, nil
+	} else if err != nil {
+		return false, "", fmt.Errorf("failed to check build config file: %w", err)
+	}
+
+	storedConfig, err := d.os.ReadFile(buildConfigPath)
+	if err != nil {
+		log.V(1).Info("Failed to read build config fingerprint, will rebuild", "error", err)
+		return true, inventoryPath, nil
+	}
+
+	currentConfig := d.currentBuildConfigFingerprint()
+	if strings.TrimSpace(string(storedConfig)) != currentConfig {
+		log.Info("Build config has changed since last build, invalidating cache and rebuilding",
+			"stored", strings.TrimSpace(string(storedConfig)),
+			"current", currentConfig)
+		return true, inventoryPath, nil
+	}
+
+	log.V(1).Info("Checksums and build config match, skipping build", "checksum", currentChecksum)
+	return false, inventoryPath, nil
 }
 
 // createInventoryDirectory creates the inventory directory
@@ -1193,25 +1232,31 @@ func (d *driverMgr) calculateDriverInventoryChecksum(ctx context.Context, invent
 	return parts[0], nil
 }
 
-// storeBuildChecksum stores the build checksum
+// storeBuildChecksum stores the build checksum and build config fingerprint so that
+// future startups can detect both file corruption and configuration drift.
 func (d *driverMgr) storeBuildChecksum(ctx context.Context, inventoryPath, kernelVersion string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	checksumPath := filepath.Join(d.cfg.NvidiaNicDriversInventoryPath, kernelVersion, d.cfg.NvidiaNicDriverVer+".checksum")
+	buildConfigPath := filepath.Join(d.cfg.NvidiaNicDriversInventoryPath, kernelVersion, d.cfg.NvidiaNicDriverVer+".buildconfig")
 
-	// Calculate current checksum
+	// Calculate and store package checksum
 	checksum, err := d.calculateDriverInventoryChecksum(ctx, inventoryPath)
 	if err != nil {
 		return fmt.Errorf("failed to calculate checksum: %w", err)
 	}
-
-	// Write checksum to file
-	err = d.os.WriteFile(checksumPath, []byte(checksum), 0o644)
-	if err != nil {
+	if err := d.os.WriteFile(checksumPath, []byte(checksum), 0o644); err != nil {
 		return fmt.Errorf("failed to write checksum file: %w", err)
 	}
-
 	log.V(1).Info("Stored build checksum", "path", checksumPath, "checksum", checksum)
+
+	// Store the build config fingerprint so cache invalidation can detect config drift
+	buildConfig := d.currentBuildConfigFingerprint()
+	if err := d.os.WriteFile(buildConfigPath, []byte(buildConfig), 0o644); err != nil {
+		return fmt.Errorf("failed to write build config file: %w", err)
+	}
+	log.V(1).Info("Stored build config fingerprint", "path", buildConfigPath)
+
 	return nil
 }
 

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -979,11 +979,16 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock checkDriverInventory to return false (skip build) - checksums match
+			// Mock checkDriverInventory to return false (skip build) - checksums and build config match
 			osMock.EXPECT().Stat(filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version")).Return(nil, nil)          // inventory directory exists
 			osMock.EXPECT().Stat(filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version.checksum")).Return(nil, nil) // checksum file exists
-			osMock.EXPECT().ReadFile(mock.Anything).Return([]byte("abc123def456"), nil)
+			// Stored package checksum
+			osMock.EXPECT().ReadFile(filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version.checksum")).Return([]byte("abc123def456"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("abc123def456", "", nil)
+			// Build config fingerprint: Stat confirms file exists, ReadFile returns matching fingerprint
+			osMock.EXPECT().Stat(filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version.buildconfig")).Return(nil, nil)
+			osMock.EXPECT().ReadFile(filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version.buildconfig")).
+				Return([]byte(dm.currentBuildConfigFingerprint()), nil)
 
 			// Mock installDriver calls (now always called even when skipping build)
 			// Mock kernel modules directory creation
@@ -1011,6 +1016,55 @@ var _ = Describe("Driver", func() {
 
 			err := dm.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should trigger rebuild when .buildconfig file is absent (backward-compat with old cache)", func() {
+			inventoryDir := filepath.Join(tempDir, "inventory")
+			Expect(os.MkdirAll(inventoryDir, 0755)).To(Succeed())
+			cfg.NvidiaNicDriversInventoryPath = inventoryDir
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			inventoryPath := filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version")
+			checksumPath := inventoryPath + ".checksum"
+			buildConfigPath := inventoryPath + ".buildconfig"
+
+			osMock.EXPECT().Stat(inventoryPath).Return(nil, nil)                             // inventory dir exists
+			osMock.EXPECT().Stat(checksumPath).Return(nil, nil)                              // checksum file exists
+			osMock.EXPECT().ReadFile(checksumPath).Return([]byte("abc123"), nil)             // stored checksum
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("abc123", "", nil) // computed checksum matches
+			osMock.EXPECT().Stat(buildConfigPath).Return(nil, os.ErrNotExist)                // .buildconfig absent → old cache
+
+			shouldBuild, path, err := dm.checkDriverInventory(ctx, "5.4.0-42-generic")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldBuild).To(BeTrue(), "expected rebuild when .buildconfig is absent")
+			Expect(path).To(Equal(inventoryPath))
+		})
+
+		It("should trigger rebuild when build config fingerprint has changed", func() {
+			inventoryDir := filepath.Join(tempDir, "inventory")
+			Expect(os.MkdirAll(inventoryDir, 0755)).To(Succeed())
+			// Enable NFS RDMA in the current config; the stored fingerprint will reflect the old config (ENABLE_NFSRDMA=false)
+			cfg.NvidiaNicDriversInventoryPath = inventoryDir
+			cfg.EnableNfsRdma = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			inventoryPath := filepath.Join(inventoryDir, "5.4.0-42-generic", "test-version")
+			checksumPath := inventoryPath + ".checksum"
+			buildConfigPath := inventoryPath + ".buildconfig"
+
+			staleConfig := "ENABLE_NFSRDMA=false\nUSE_DKMS=false\nAPPEND_DRIVER_BUILD_FLAGS="
+
+			osMock.EXPECT().Stat(inventoryPath).Return(nil, nil)                                  // inventory dir exists
+			osMock.EXPECT().Stat(checksumPath).Return(nil, nil)                                   // checksum file exists
+			osMock.EXPECT().ReadFile(checksumPath).Return([]byte("abc123"), nil)                  // stored checksum
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("abc123", "", nil) // computed checksum matches
+			osMock.EXPECT().Stat(buildConfigPath).Return(nil, nil)                                // .buildconfig exists
+			osMock.EXPECT().ReadFile(buildConfigPath).Return([]byte(staleConfig), nil)            // but reflects old flags
+
+			shouldBuild, path, err := dm.checkDriverInventory(ctx, "5.4.0-42-generic")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(shouldBuild).To(BeTrue(), "expected rebuild when ENABLE_NFSRDMA changed from false to true")
+			Expect(path).To(Equal(inventoryPath))
 		})
 
 		It("should build driver successfully for Ubuntu", func() {

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -1370,6 +1370,34 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
+		It("should not install kernel prerequisites for a DTK build", func() {
+			// Regression test: installPrerequisitesForOS must be skipped entirely for
+			// DTK builds. The DTK sidecar handles compilation; kernel headers are not
+			// needed and the container repos may not carry the kernel packages.
+			//
+			// No mock for GetRedHatVersionInfo is registered.  If
+			// installPrerequisitesForOS were called it would invoke GetRedHatVersionInfo,
+			// which the mock framework would report as an unexpected call — catching the
+			// regression immediately.
+			cfg.DtkOcpDriverBuild = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.14.0-570.78.1.el9_6.x86_64", nil)
+			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeOpenShift, nil)
+
+			// No NvidiaNicDriversInventoryPath set → checkDriverInventory returns
+			// shouldBuild=true immediately, without any Stat/ReadFile calls.
+
+			// DTK setup: done flag absent, then MkdirAll fails — keeps the mock surface
+			// minimal without having to wire up the entire DTK pipeline.
+			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // done flag not present
+			osMock.EXPECT().MkdirAll(mock.Anything, mock.Anything).Return(errors.New("mkdir failed"))
+
+			err := dm.Build(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to setup DTK build"))
+		})
+
 		It("should return error when createInventoryDirectory fails", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)


### PR DESCRIPTION
The inventory cache check only validated kernel version, driver version, and an MD5 of the cached package files. It did not account for build- affecting env vars (ENABLE_NFSRDMA, USE_DKMS, APPEND_DRIVER_BUILD_FLAGS). Changing any of these flags while the same kernel and driver version remained in the cache caused the stale build to be reused, resulting in missing modules (e.g. kmod-mlnx-nfsrdma) and a failing validator daemonset.

Introduce a .buildconfig sidecar file written alongside .checksum after every successful build. On startup, after the package checksum passes, the stored fingerprint is compared to the current config. A mismatch or absent fingerprint (old cache) forces a full rebuild. This covers both the Go entrypoint (driver.go) and the legacy bash entrypoint (entrypoint.sh).