### PR TITLE
add ib_iser/ib_srp to storage defaults; make third-party RDMA list configurable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,8 +56,9 @@
 # Example: UNLOAD_THIRD_PARTY_RDMA_MODULES=true
 : ${UNLOAD_THIRD_PARTY_RDMA_MODULES:=false}
 
-# Hardcoded list of known third-party RDMA modules (non-NVIDIA, from rdma-core)
-THIRD_PARTY_RDMA_MODULES="bnxt_re efa erdma iw_cxgb4 hfi1 hns_roce ionic_rdma irdma ib_qib mana_ib ocrdma qedr rdma_rxe siw vmw_pvrdma"
+# Known third-party RDMA modules (non-NVIDIA, from rdma-core). Override via env var if needed.
+# Space-separated to match the Go envSeparator and bash word-splitting — no translation needed.
+THIRD_PARTY_RDMA_MODULES="${THIRD_PARTY_RDMA_MODULES:-bnxt_re efa erdma iw_cxgb4 hfi1 hns_roce ionic_rdma irdma ib_qib mana_ib ocrdma qedr rdma_rxe siw vmw_pvrdma}"
 
 : ${UBUNTU_PRO_TOKEN:=""}
 
@@ -505,7 +506,9 @@ function unload_storage_modules() {
         unload_storage_script="/usr/share/mlnx_ofed/mod_load_funcs"
     fi
 
-    sed -i -e '/^[[:space:]]*UNLOAD_MODULES="[a-z]/a\    UNLOAD_MODULES="$UNLOAD_MODULES ib_isert nvme_rdma nvmet_rdma rpcrdma xprtrdma ib_srpt"' ${unload_storage_script}
+    # STORAGE_MODULES is space-separated (matches Go config envSeparator and bash word-splitting).
+    storage_modules_list="${STORAGE_MODULES:-ib_iser ib_isert ib_srp ib_srpt nvme_rdma nvmet_rdma rpcrdma xprtrdma}"
+    sed -i -e "/^[[:space:]]*UNLOAD_MODULES=\"[a-z]/a\\    UNLOAD_MODULES=\"\$UNLOAD_MODULES ${storage_modules_list}\"" ${unload_storage_script}
 
     if [ `grep ib_isert ${unload_storage_script} -c` -lt 1 ]; then
         timestamp_print "Failed to inject storage modules for unload"
@@ -546,7 +549,8 @@ function generate_ofed_modules_blacklist(){
         echo "blacklist $component" >> ${OFED_BLACKLIST_MODULES_FILE}
     done
 
-    # Append third-party RDMA modules to blacklist if enabled
+    # Append third-party RDMA modules to blacklist if enabled. THIRD_PARTY_RDMA_MODULES is
+    # space-separated so default bash word-splitting iterates correctly.
     if ${UNLOAD_THIRD_PARTY_RDMA_MODULES}; then
         echo -e "\n# blacklist third-party RDMA modules to prevent reload conflicts" >> ${OFED_BLACKLIST_MODULES_FILE}
         for mod in ${THIRD_PARTY_RDMA_MODULES}; do

--- a/entrypoint/internal/config/config.go
+++ b/entrypoint/internal/config/config.go
@@ -19,6 +19,8 @@ package config
 
 import (
 	"github.com/caarlos0/env/v11"
+
+	"github.com/Mellanox/doca-driver-build/entrypoint/pkg/mofedmodules"
 )
 
 // Config contains configuration for the entrypoint.
@@ -51,7 +53,10 @@ type Config struct {
 
 	OfedBlacklistModulesFile string   `env:"OFED_BLACKLIST_MODULES_FILE" envDefault:"/host/etc/modprobe.d/blacklist-ofed-modules.conf"`
 	OfedBlacklistModules     []string `env:"OFED_BLACKLIST_MODULES"      envDefault:"mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm" envSeparator:":"`
-	StorageModules           []string `env:"STORAGE_MODULES"             envDefault:"ib_isert:nvme_rdma:nvmet_rdma:rpcrdma:xprtrdma:ib_srpt"                      envSeparator:":"`
+	// StorageModules defaults to mofedmodules.DefaultStorageModules when unset; see GetConfig.
+	StorageModules []string `env:"STORAGE_MODULES" envSeparator:" "`
+	// ThirdPartyRDMAModules defaults to mofedmodules.DefaultThirdPartyRDMAModules when unset; see GetConfig.
+	ThirdPartyRDMAModules []string `env:"THIRD_PARTY_RDMA_MODULES" envSeparator:" "`
 
 	// DKMS settings
 	UseDKMS bool `env:"USE_DKMS" envDefault:"false"`
@@ -71,24 +76,19 @@ type Config struct {
 	BindDelaySec        int    `env:"BIND_DELAY_SEC"          envDefault:"4"`
 }
 
-// ThirdPartyRDMAModules is the hardcoded list of known third-party RDMA kernel modules
-// (non-NVIDIA modules from the rdma-core ecosystem) that can block MOFED driver reload.
-// This list is used when UnloadThirdPartyRdmaModules is true.
-//
-// NOTE: Do NOT add core RDMA infrastructure modules (iw_cm, ib_cm, rdma_cm, etc.)
-// here — MOFED manages those in its own unload sequence. Do NOT add storage-over-RDMA
-// modules that are already handled by UNLOAD_STORAGE_MODULES (StorageModules).
-var ThirdPartyRDMAModules = []string{
-	"bnxt_re", "efa", "erdma", "iw_cxgb4", "hfi1", "hns_roce",
-	"ionic_rdma", "irdma", "ib_qib", "mana_ib", "ocrdma", "qedr",
-	"rdma_rxe", "siw", "vmw_pvrdma",
-}
-
 // GetConfig parses environment variables and returns a Config struct.
+// When STORAGE_MODULES or THIRD_PARTY_RDMA_MODULES is unset, the corresponding
+// slice is populated from the canonical defaults in the mofedmodules package.
 func GetConfig() (Config, error) {
 	var cfg Config
 	if err := env.Parse(&cfg); err != nil {
 		return Config{}, err
+	}
+	if len(cfg.StorageModules) == 0 {
+		cfg.StorageModules = append(cfg.StorageModules, mofedmodules.DefaultStorageModules...)
+	}
+	if len(cfg.ThirdPartyRDMAModules) == 0 {
+		cfg.ThirdPartyRDMAModules = append(cfg.ThirdPartyRDMAModules, mofedmodules.DefaultThirdPartyRDMAModules...)
 	}
 	return cfg, nil
 }

--- a/entrypoint/internal/config/config_test.go
+++ b/entrypoint/internal/config/config_test.go
@@ -32,6 +32,8 @@ var _ = Describe("Config", func() {
 	AfterEach(func() {
 		os.Unsetenv("NVIDIA_NIC_DRIVER_VER")
 		os.Unsetenv("UNLOAD_THIRD_PARTY_RDMA_MODULES")
+		os.Unsetenv("THIRD_PARTY_RDMA_MODULES")
+		os.Unsetenv("STORAGE_MODULES")
 	})
 
 	Context("UnloadThirdPartyRdmaModules", func() {
@@ -57,6 +59,44 @@ var _ = Describe("Config", func() {
 			cfg, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.UnloadThirdPartyRdmaModules).To(BeFalse())
+		})
+	})
+
+	Context("StorageModules", func() {
+		It("should include ib_iser and ib_srp in the default list", func() {
+			os.Unsetenv("STORAGE_MODULES")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.StorageModules).To(ContainElement("ib_iser"))
+			Expect(cfg.StorageModules).To(ContainElement("ib_srp"))
+			Expect(cfg.StorageModules).To(ContainElement("ib_isert"))
+			Expect(cfg.StorageModules).To(ContainElement("ib_srpt"))
+			Expect(cfg.StorageModules).To(ContainElement("nvme_rdma"))
+			Expect(cfg.StorageModules).To(ContainElement("nvmet_rdma"))
+			Expect(cfg.StorageModules).To(ContainElement("rpcrdma"))
+			Expect(cfg.StorageModules).To(ContainElement("xprtrdma"))
+		})
+	})
+
+	Context("ThirdPartyRDMAModules", func() {
+		It("should parse the default list when THIRD_PARTY_RDMA_MODULES is not set", func() {
+			os.Unsetenv("THIRD_PARTY_RDMA_MODULES")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ThirdPartyRDMAModules).To(ContainElement("bnxt_re"))
+			Expect(cfg.ThirdPartyRDMAModules).To(ContainElement("qedr"))
+			Expect(cfg.ThirdPartyRDMAModules).To(ContainElement("siw"))
+			Expect(cfg.ThirdPartyRDMAModules).To(HaveLen(15))
+		})
+
+		It("should parse a space-separated override correctly", func() {
+			os.Setenv("THIRD_PARTY_RDMA_MODULES", "foo_re bar_rdma baz_ib")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.ThirdPartyRDMAModules).To(Equal([]string{"foo_re", "bar_rdma", "baz_ib"}))
 		})
 	})
 })

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -806,7 +806,7 @@ func (d *driverMgr) generateOfedModulesBlacklist(ctx context.Context) error {
 
 	if d.cfg.UnloadThirdPartyRdmaModules {
 		content.WriteString("\n# blacklist third-party RDMA modules to prevent reload conflicts\n")
-		for _, module := range config.ThirdPartyRDMAModules {
+		for _, module := range d.cfg.ThirdPartyRDMAModules {
 			fmt.Fprintf(&content, "blacklist %s\n", module)
 			log.V(2).Info("Added third-party RDMA module to blacklist", "module", module)
 		}

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -3744,9 +3744,15 @@ var _ = Describe("Driver OFED Blacklist", func() {
 
 		It("should include third-party RDMA modules in blacklist when flag is true", func() {
 			blacklistFile := filepath.Join(tempDir, "third-party-rdma-blacklist.conf")
+			thirdPartyModules := []string{
+				"bnxt_re", "efa", "erdma", "iw_cxgb4", "hfi1", "hns_roce",
+				"ionic_rdma", "irdma", "ib_qib", "mana_ib", "ocrdma", "qedr",
+				"rdma_rxe", "siw", "vmw_pvrdma",
+			}
 			cfg := config.Config{
-				OfedBlacklistModulesFile:     blacklistFile,
-				OfedBlacklistModules:         []string{"mlx5_core", "mlx5_ib"},
+				OfedBlacklistModulesFile:    blacklistFile,
+				OfedBlacklistModules:        []string{"mlx5_core", "mlx5_ib"},
+				ThirdPartyRDMAModules:       thirdPartyModules,
 				UnloadThirdPartyRdmaModules: true,
 			}
 
@@ -3778,7 +3784,7 @@ var _ = Describe("Driver OFED Blacklist", func() {
 			Expect(contentStr).To(ContainSubstring("blacklist qedr"))
 			Expect(contentStr).To(ContainSubstring("blacklist siw"))
 
-			// Count blacklist lines - should be 2 OFED + len(ThirdPartyRDMAModules)
+			// Count blacklist lines - should be 2 OFED + len(thirdPartyModules)
 			lines := strings.Split(contentStr, "\n")
 			blacklistLines := 0
 			for _, line := range lines {
@@ -3786,7 +3792,7 @@ var _ = Describe("Driver OFED Blacklist", func() {
 					blacklistLines++
 				}
 			}
-			Expect(blacklistLines).To(Equal(2 + len(config.ThirdPartyRDMAModules)))
+			Expect(blacklistLines).To(Equal(2 + len(thirdPartyModules)))
 		})
 
 		It("should not include third-party RDMA modules section when flag is false", func() {

--- a/entrypoint/internal/entrypoint/entrypoint.go
+++ b/entrypoint/internal/entrypoint/entrypoint.go
@@ -313,7 +313,7 @@ func (e *entrypoint) handleKernelModules(ctx context.Context) error {
 	if e.config.UnloadThirdPartyRdmaModules {
 		// third-party RDMA modules will be unloaded by the openibd restart, no need to check if they are loaded
 	} else {
-		for _, mod := range config.ThirdPartyRDMAModules {
+		for _, mod := range e.config.ThirdPartyRDMAModules {
 			if _, found := loadedModules[mod]; found {
 				err = fmt.Errorf("third-party RDMA modules are loaded for current driver," +
 					"terminating prior driver reload failure due to " +

--- a/entrypoint/pkg/mofedmodules/mofedmodules.go
+++ b/entrypoint/pkg/mofedmodules/mofedmodules.go
@@ -1,0 +1,49 @@
+/*
+ Copyright 2026, NVIDIA CORPORATION & AFFILIATES
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+// Package mofedmodules exposes the canonical default lists of kernel modules
+// that the MOFED driver container unloads before reloading the OFED driver.
+// This package is the single source of truth shared with other repositories
+// (notably network-operator-init-container) so the pre-flight checker and the
+// driver container agree on what counts as a known third-party RDMA or
+// storage-over-RDMA module.
+package mofedmodules
+
+// Separator is the character used to join module names when serialized into
+// env var values (e.g. STORAGE_MODULES, THIRD_PARTY_RDMA_MODULES). A single
+// space keeps the bash- and Go-side representations identical.
+const Separator = " "
+
+// DefaultStorageModules is the list of storage-over-RDMA kernel modules that
+// the driver container unloads when UNLOAD_STORAGE_MODULES=true. Includes
+// both initiator (ib_iser, ib_srp, nvme_rdma, rpcrdma/xprtrdma) and target
+// (ib_isert, ib_srpt, nvmet_rdma) sides of iSCSI, SRP, NVMe and NFS over RDMA.
+var DefaultStorageModules = []string{
+	"ib_iser", "ib_isert", "ib_srp", "ib_srpt",
+	"nvme_rdma", "nvmet_rdma", "rpcrdma", "xprtrdma",
+}
+
+// DefaultThirdPartyRDMAModules is the list of non-NVIDIA NIC-vendor RDMA
+// provider modules (from rdma-core) that the driver container unloads when
+// UNLOAD_THIRD_PARTY_RDMA_MODULES=true.
+//
+// Do NOT add core RDMA infrastructure modules (iw_cm, ib_cm, rdma_cm,
+// rdma_ucm, ib_core, ib_uverbs, etc.) — MOFED manages those in its own
+// openibd unload sequence. Do NOT add storage-over-RDMA modules — those
+// belong in DefaultStorageModules.
+var DefaultThirdPartyRDMAModules = []string{
+	"bnxt_re", "efa", "erdma", "iw_cxgb4",
+	"hfi1", "hns_roce", "ionic_rdma", "irdma",
+	"ib_qib", "mana_ib", "ocrdma", "qedr",
+	"rdma_rxe", "siw", "vmw_pvrdma",
+}


### PR DESCRIPTION
Adds ib_iser and ib_srp to the default STORAGE_MODULES list so storage-over-RDMA initiator modules loaded by Ubuntu 24.04 (and similar) are recognized and handled by the storage unload path instead of tripping the unknown-module check.

Promotes ThirdPartyRDMAModules from a package-level hardcoded var to a Config struct field sourced from the THIRD_PARTY_RDMA_MODULES env var (colon-separated, same as STORAGE_MODULES), so users can extend or override the list without a code change. entrypoint.sh gets the matching override ability and the UNLOAD_MODULES sed injection now derives from STORAGE_MODULES.