### PR TITLE
fix: reduce DTK build poll interval from 300s to 30s

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1302,16 +1302,15 @@ function build_driver() {
             dtk_ocp_setup_driver_build
 
             # Await driver build completion
-            sleep_sec=300
-            total_retries=10
+            # Poll every 30s (air-gapped builds from local RPM repos typically finish in ~180s).
+            # Max total timeout: sleep_sec * total_retries = 30 * 30 = 900s.
+            sleep_sec=30
+            total_retries=30
             total_sleep_sec=0
             while [ ! -f "${DTK_OCP_DONE_COMPILE_FLAG}" ] && [ ${total_retries} -gt 0 ]; do
                 timestamp_print "Awaiting openshift driver toolkit to complete NIC driver build, next query in ${sleep_sec} sec"
                 sleep ${sleep_sec}
                 let total_sleep_sec+=sleep_sec
-                if [ $sleep_sec -gt 10 ]; then
-                    sleep_sec=$((sleep_sec/2))
-                fi
                 total_retries=$((total_retries-1))
             done
             if [ ${total_retries} -eq 0 ]; then

--- a/entrypoint/internal/driver/driver_dtk.go
+++ b/entrypoint/internal/driver/driver_dtk.go
@@ -157,8 +157,10 @@ func (d *driverMgr) dtkWaitForBuild(ctx context.Context, doneFlagPath string) er
 	log := logr.FromContextOrDiscard(ctx)
 	log.Info("Waiting for DTK build to complete", "doneFlag", doneFlagPath)
 
-	sleepSec := 300
-	totalRetries := 10
+	// Poll every 30s (air-gapped builds from local RPM repos typically finish in ~180s).
+	// Max total timeout: sleepSec * totalRetries = 30 * 30 = 900s.
+	sleepSec := 30
+	totalRetries := 30
 	totalSleepSec := 0
 
 	for totalRetries > 0 {
@@ -176,9 +178,6 @@ func (d *driverMgr) dtkWaitForBuild(ctx context.Context, doneFlagPath string) er
 		}
 
 		totalSleepSec += sleepSec
-		if sleepSec > 10 {
-			sleepSec /= 2
-		}
 		totalRetries--
 	}
 


### PR DESCRIPTION
Air-gapped builds from a local RPM repository complete in ~180s, making the previous 300s initial wait unnecessarily long. Poll every 30s with 30 retries (900s max timeout) and remove the halving logic for a predictable, fixed interval. Applied consistently to both entrypoint.sh and the Go implementation in driver_dtk.go.

Fix: #198