### PR TITLE
fix(dtk): pass --without-dkms to install.pl only when USE_DKMS is false

### DIFF
--- a/dtk_nic_driver_build.sh
+++ b/dtk_nic_driver_build.sh
@@ -72,12 +72,17 @@ done
 
 timestamp_print "Starting compilation of driver version ${DTK_OCP_COMPILED_DRIVER_VER}"
 
-COMMON_BUILD_FLAGS="--build-only --kernel-only --without-knem --without-iser --without-isert --without-srp --with-mlnx-tools --with-ofed-scripts --copy-ifnames-udev --disable-kmp --without-xpmem --without-xpmem-modules"
+COMMON_BUILD_FLAGS="--build-only --kernel-only --without-knem --without-iser --without-isert --without-srp --with-mlnx-tools --with-ofed-scripts --copy-ifnames-udev --without-xpmem --without-xpmem-modules"
 
 if [[ "${USE_DKMS}" = true ]]; then
+    # DKMS path: omit --disable-kmp so that install.pl produces both the DKMS source
+    # package (for dkms add registration) and pre-compiled kmod binary packages (which
+    # place .ko files without requiring kernel headers in the main container).
     exec_cmd "${DTK_OCP_NIC_SHARED_DIR}/MLNX_OFED_SRC-${DTK_OCP_COMPILED_DRIVER_VER}/install.pl ${COMMON_BUILD_FLAGS} --without-xpmem-dkms ${append_driver_build_flags}"
 else
-    exec_cmd "${DTK_OCP_NIC_SHARED_DIR}/MLNX_OFED_SRC-${DTK_OCP_COMPILED_DRIVER_VER}/install.pl ${COMMON_BUILD_FLAGS} --without-dkms ${append_driver_build_flags}"
+    # Non-DKMS path: suppress DKMS source packages and kmod binary packages; produce
+    # only static kernel module packages.
+    exec_cmd "${DTK_OCP_NIC_SHARED_DIR}/MLNX_OFED_SRC-${DTK_OCP_COMPILED_DRIVER_VER}/install.pl ${COMMON_BUILD_FLAGS} --disable-kmp --without-dkms ${append_driver_build_flags}"
 fi
 
 exec_cmd "touch ${DTK_OCP_DONE_COMPILE_FLAG}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1286,6 +1286,9 @@ function build_driver() {
         driver_inventory_path=/tmp/nvidia_nic_driver_$(date +"%d-%m-%Y_%H-%M-%S")
     fi
 
+    # Wipe any stale inventory directory before rebuilding to prevent RPM file
+    # conflicts when build config changes between runs (e.g. USE_DKMS toggled).
+    exec_cmd "rm -rf ${driver_inventory_path}"
     exec_cmd "mkdir -p ${driver_inventory_path}"
     debug_print "Driver modules dest path: ${driver_inventory_path}"
 
@@ -1302,10 +1305,11 @@ function build_driver() {
             dtk_ocp_setup_driver_build
 
             # Await driver build completion
-            # Poll every 30s (air-gapped builds from local RPM repos typically finish in ~180s).
-            # Max total timeout: sleep_sec * total_retries = 30 * 30 = 900s.
+            # Poll every 30s. Air-gapped builds from local RPM repos typically finish in ~180s,
+            # but full first-time DTK compilations on slower nodes can exceed 15 min.
+            # Max total timeout: sleep_sec * total_retries = 30 * 120 = 3600s (60 min).
             sleep_sec=30
-            total_retries=30
+            total_retries=120
             total_sleep_sec=0
             while [ ! -f "${DTK_OCP_DONE_COMPILE_FLAG}" ] && [ ${total_retries} -gt 0 ]; do
                 timestamp_print "Awaiting openshift driver toolkit to complete NIC driver build, next query in ${sleep_sec} sec"
@@ -1511,10 +1515,20 @@ function setup_dkms() {
     # Step 3: Add module to DKMS
     dkms_add
 
-    # Step 4: Build module for current kernel
+    # Step 4: In the DTK/OCP path the DTK sidecar compiled the driver and produced
+    # pre-compiled kmod binary packages that installDriver already placed at the correct
+    # /lib/modules/<kernel>/ path.  The main container does NOT have kernel headers so
+    # dkms build would fail.  Skip dkms build and dkms install: the modules are already
+    # in place via the kmod RPMs.
+    if [[ "${DTK_OCP_DRIVER_BUILD}" == "true" ]]; then
+        timestamp_print "DTK build path: skipping dkms build/install (kmod packages already placed modules)"
+        return 0
+    fi
+
+    # Step 5: Build module for current kernel
     dkms_build
 
-    # Step 5: Install module
+    # Step 6: Install module
     dkms_install
 
     timestamp_print "DKMS setup completed successfully"
@@ -1526,21 +1540,27 @@ function discover_dkms_module_info() {
     DKMS_MODULE_NAME=""
     DKMS_MODULE_VERSION=""
 
-    # Prioritize mlnx-ofa_kernel — it's the primary DKMS module for the NIC driver
+    # Prioritize mlnx-ofa_kernel — it's the primary DKMS module for the NIC driver.
+    # Check both the top-level dir and a nested source/ subdirectory: newer OFED packages
+    # (e.g. OFED 26.04) place dkms.conf under <dir>/source/ rather than directly under
+    # <dir>. The directory entry may also be a symlink, so use -L || -d to handle both.
     for dir in /usr/src/mlnx-ofa_kernel-* /usr/src/*; do
-        if [ -d "${dir}" ] && [ -f "${dir}/dkms.conf" ]; then
-            debug_print "Found dkms.conf in ${dir}"
+        [ -L "${dir}" ] || [ -d "${dir}" ] || continue
+        for dkms_conf in "${dir}/dkms.conf" "${dir}/source/dkms.conf"; do
+            if [ -f "${dkms_conf}" ]; then
+                debug_print "Found dkms.conf at ${dkms_conf}"
 
-            local name=$(grep "^PACKAGE_NAME=" "${dir}/dkms.conf" | sed "s/^PACKAGE_NAME=//;s/[\"']//g")
-            local version=$(grep "^PACKAGE_VERSION=" "${dir}/dkms.conf" | sed "s/^PACKAGE_VERSION=//;s/[\"']//g")
+                local name=$(grep "^PACKAGE_NAME=" "${dkms_conf}" | sed "s/^PACKAGE_NAME=//;s/[\"']//g")
+                local version=$(grep "^PACKAGE_VERSION=" "${dkms_conf}" | sed "s/^PACKAGE_VERSION=//;s/[\"']//g")
 
-            if [ -n "${name}" ] && [ -n "${version}" ]; then
-                DKMS_MODULE_NAME="${name}"
-                DKMS_MODULE_VERSION="${version}"
-                debug_print "Found DKMS module: ${DKMS_MODULE_NAME}/${DKMS_MODULE_VERSION}"
-                return 0
+                if [ -n "${name}" ] && [ -n "${version}" ]; then
+                    DKMS_MODULE_NAME="${name}"
+                    DKMS_MODULE_VERSION="${version}"
+                    debug_print "Found DKMS module: ${DKMS_MODULE_NAME}/${DKMS_MODULE_VERSION}"
+                    return 0
+                fi
             fi
-        fi
+        done
     done
 
     return 1

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -182,6 +182,13 @@ func (d *driverMgr) Build(ctx context.Context) error {
 		// Mark build as incomplete at the start
 		d.driverBuildIncomplete = true
 
+		// Wipe any stale inventory directory before rebuilding to prevent RPM file
+		// conflicts when build config changes between runs (e.g. USE_DKMS toggled).
+		// RemoveAll is a no-op when the path does not exist.
+		if err := d.os.RemoveAll(inventoryPath); err != nil {
+			return fmt.Errorf("failed to clean inventory directory: %w", err)
+		}
+
 		// Check if DTK OCP driver build is enabled
 		if d.cfg.DtkOcpDriverBuild {
 			if err := d.buildDriverDTK(ctx, kernelVersion, inventoryPath); err != nil {
@@ -2115,12 +2122,23 @@ func (d *driverMgr) setupDKMS(ctx context.Context, kernelVersion string) error {
 		return fmt.Errorf("failed to add DKMS module: %w", err)
 	}
 
-	// Step 4: Build module for current kernel
+	// Step 4: In the DTK/OCP path the DTK sidecar compiled the driver using its
+	// kernel headers and produced pre-compiled kmod binary packages that installDriver
+	// already placed at the correct /lib/modules/<kernel>/ path.  The main driver
+	// container does NOT have kernel headers, so dkms build would fail.  Skip
+	// dkms build and dkms install: the modules are already in place via the kmod RPMs.
+	if d.cfg.DtkOcpDriverBuild {
+		log.Info("DTK build path: skipping dkms build/install (kmod packages already placed modules)",
+			"module", moduleName, "version", moduleVersion, "kernel", kernelVersion)
+		return nil
+	}
+
+	// Step 5: Build module for current kernel
 	if err := d.dkmsBuild(ctx, moduleName, moduleVersion, kernelVersion); err != nil {
 		return fmt.Errorf("failed to build DKMS module: %w", err)
 	}
 
-	// Step 5: Install module
+	// Step 6: Install module
 	if err := d.dkmsInstall(ctx, moduleName, moduleVersion, kernelVersion); err != nil {
 		return fmt.Errorf("failed to install DKMS module: %w", err)
 	}
@@ -2134,17 +2152,33 @@ func (d *driverMgr) setupDKMS(ctx context.Context, kernelVersion string) error {
 // is the primary NIC driver DKMS module, then falls back to any other directory with dkms.conf.
 // Returns the module name, module version, and an error if no valid DKMS module is found.
 func (d *driverMgr) discoverDKMSModule(ctx context.Context) (string, string, error) {
+	return d.discoverDKMSModuleIn(ctx, "/usr/src/")
+}
+
+// discoverDKMSModuleIn is the testable implementation of discoverDKMSModule that accepts a
+// configurable base directory instead of the hardcoded /usr/src.
+func (d *driverMgr) discoverDKMSModuleIn(ctx context.Context, srcBaseDir string) (string, string, error) {
 	log := logr.FromContextOrDiscard(ctx)
 
-	entries, err := d.os.ReadDir("/usr/src/")
+	entries, err := d.os.ReadDir(srcBaseDir)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to read /usr/src/: %w", err)
+		return "", "", fmt.Errorf("failed to read %s: %w", srcBaseDir, err)
 	}
 
 	// Two-pass scan: first mlnx-ofa_kernel-* directories, then everything else
 	for pass := range 2 {
 		for _, entry := range entries {
-			if !entry.IsDir() {
+			entryPath := filepath.Join(srcBaseDir, entry.Name())
+
+			// entry.IsDir() returns false for symlinks even when pointing at a directory;
+			// use Stat (which follows symlinks) to correctly identify directory entries.
+			isDir := entry.IsDir()
+			if !isDir {
+				if fi, statErr := d.os.Stat(entryPath); statErr == nil {
+					isDir = fi.IsDir()
+				}
+			}
+			if !isDir {
 				continue
 			}
 
@@ -2155,24 +2189,36 @@ func (d *driverMgr) discoverDKMSModule(ctx context.Context) (string, string, err
 				continue
 			}
 
-			dkmsConfPath := filepath.Join("/usr/src", dirName, "dkms.conf")
+			// Check both the top-level dir and a nested source/ subdirectory.
+			// Newer OFED packages (e.g. mlnx-ofa_kernel-source in OFED 26.04) place
+			// dkms.conf under <dir>/source/ rather than directly under <dir>. The
+			// mlnx-ofa_kernel-<ver> directory may also be a symlink pointing at the
+			// ofa_kernel-<ver>/source directory, which os.ReadDir reports as a non-dir
+			// entry (IsDir() == false for symlinks), hence the Stat() follow above.
+			candidatePaths := []string{
+				filepath.Join(entryPath, "dkms.conf"),
+				filepath.Join(entryPath, "source", "dkms.conf"),
+			}
 
-			if _, err := d.os.Stat(dkmsConfPath); err == nil {
-				moduleName, moduleVersion, err := d.parseDKMSConf(dkmsConfPath)
-				if err != nil {
-					log.V(1).Info("Failed to parse dkms.conf", "path", dkmsConfPath, "error", err)
-					continue
+			for _, dkmsConfPath := range candidatePaths {
+				if _, err := d.os.Stat(dkmsConfPath); err == nil {
+					moduleName, moduleVersion, err := d.parseDKMSConf(dkmsConfPath)
+					if err != nil {
+						log.V(1).Info("Failed to parse dkms.conf", "path", dkmsConfPath, "error", err)
+						continue
+					}
+
+					log.V(1).Info("Found DKMS module", "dir", dirName, "name", moduleName, "version", moduleVersion)
+					return moduleName, moduleVersion, nil
 				}
-
-				log.V(1).Info("Found DKMS module", "dir", dirName, "name", moduleName, "version", moduleVersion)
-				return moduleName, moduleVersion, nil
 			}
 		}
 	}
 
 	return "", "", fmt.Errorf(
-		"no DKMS module found in /usr/src/. This may indicate that install.pl did not create DKMS-enabled packages. " +
-			"Verify that install.pl was run without --without-dkms flag and that the packages were installed correctly")
+		"no DKMS module found in %s. This may indicate that install.pl did not create DKMS-enabled packages. "+
+			"Verify that install.pl was run without --without-dkms flag and that the packages were installed correctly",
+		srcBaseDir)
 }
 
 // parseDKMSConf reads the dkms.conf at dkmsConfPath and extracts PACKAGE_NAME and PACKAGE_VERSION.

--- a/entrypoint/internal/driver/driver_dtk.go
+++ b/entrypoint/internal/driver/driver_dtk.go
@@ -127,7 +127,8 @@ export DTK_OCP_DONE_COMPILE_FLAG="%s"
 export APPEND_DRIVER_BUILD_FLAGS="%s"
 export USE_NEW_ENTRYPOINT="true"
 export NVIDIA_NIC_DRIVER_VER="%s"
-`, sharedDir, d.cfg.NvidiaNicDriverVer, startFlagPath, doneFlagPath, appendFlagsStr, d.cfg.NvidiaNicDriverVer)
+export USE_DKMS="%v"
+`, sharedDir, d.cfg.NvidiaNicDriverVer, startFlagPath, doneFlagPath, appendFlagsStr, d.cfg.NvidiaNicDriverVer, d.cfg.UseDKMS)
 
 	envPath := filepath.Join(sharedDir, "dtk.env")
 	if err := d.os.WriteFile(envPath, []byte(envContent), 0o644); err != nil {
@@ -157,10 +158,11 @@ func (d *driverMgr) dtkWaitForBuild(ctx context.Context, doneFlagPath string) er
 	log := logr.FromContextOrDiscard(ctx)
 	log.Info("Waiting for DTK build to complete", "doneFlag", doneFlagPath)
 
-	// Poll every 30s (air-gapped builds from local RPM repos typically finish in ~180s).
-	// Max total timeout: sleepSec * totalRetries = 30 * 30 = 900s.
+	// Poll every 30s. Air-gapped builds from local RPM repos typically finish in ~180s,
+	// but full first-time DTK compilations on slower nodes can exceed 15 min.
+	// Max total timeout: sleepSec * totalRetries = 30 * 80 = 2400s (40 min).
 	sleepSec := 30
-	totalRetries := 30
+	totalRetries := 80
 	totalSleepSec := 0
 
 	for totalRetries > 0 {

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -1071,14 +1071,15 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// UseDKMS false by default → install.pl must include --without-dkms
+		// UseDKMS false by default → install.pl must include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
@@ -1131,14 +1132,15 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// UseDKMS true → install.pl must NOT include --without-dkms
+		// UseDKMS true → install.pl must NOT include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
@@ -1186,13 +1188,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-default", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeSLES, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			// This will cause checkDriverInventory to return true
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		// This will cause checkDriverInventory to return true
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installSLESPrerequisites
+		// Mock installSLESPrerequisites
 			cmdMock.EXPECT().RunCommand(ctx, "zypper", "--non-interactive", "install", "--no-recommends", "kernel-default-devel=5.4.0-42").Return("", "", nil)
 
 			// Mock buildDriverFromSource - SLES specific arguments
@@ -1238,17 +1241,18 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeRedHat, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			// This will cause checkDriverInventory to return true
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		// This will cause checkDriverInventory to return true
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installRedHatPrerequisites
-			versionInfo := &host.RedhatVersionInfo{
-				MajorVersion:     8,
-				FullVersion:      "8.4",
-				OpenShiftVersion: "",
+		// Mock installRedHatPrerequisites
+		versionInfo := &host.RedhatVersionInfo{
+			MajorVersion:     8,
+			FullVersion:      "8.4",
+			OpenShiftVersion: "",
 			}
 			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
@@ -1305,13 +1309,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeOpenShift, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			// This will cause checkDriverInventory to return true
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		// This will cause checkDriverInventory to return true
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installRedHatPrerequisites for OpenShift
+		// Mock installRedHatPrerequisites for OpenShift
 			versionInfo := &host.RedhatVersionInfo{
 				MajorVersion:     8,
 				FullVersion:      "8.4",
@@ -1385,13 +1390,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.14.0-570.78.1.el9_6.x86_64", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeOpenShift, nil)
 
-			// No NvidiaNicDriversInventoryPath set → checkDriverInventory returns
-			// shouldBuild=true immediately, without any Stat/ReadFile calls.
+		// No NvidiaNicDriversInventoryPath set → checkDriverInventory returns
+		// shouldBuild=true immediately, without any Stat/ReadFile calls.
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// DTK setup: done flag absent, then MkdirAll fails — keeps the mock surface
-			// minimal without having to wire up the entire DTK pipeline.
-			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // done flag not present
-			osMock.EXPECT().MkdirAll(mock.Anything, mock.Anything).Return(errors.New("mkdir failed"))
+		// DTK setup: done flag absent, then MkdirAll fails — keeps the mock surface
+		// minimal without having to wire up the entire DTK pipeline.
+		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // done flag not present
+		osMock.EXPECT().MkdirAll(mock.Anything, mock.Anything).Return(errors.New("mkdir failed"))
 
 			err := dm.Build(ctx)
 			Expect(err).To(HaveOccurred())
@@ -1406,9 +1412,10 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock createInventoryDirectory failure
-			expectedError := errors.New("mkdir failed")
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", expectedError)
+		// Mock createInventoryDirectory failure
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+		expectedError := errors.New("mkdir failed")
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", expectedError)
 
 			err := dm.Build(ctx)
 			Expect(err).To(HaveOccurred())
@@ -1435,14 +1442,15 @@ var _ = Describe("Driver", func() {
 			// Mock checkDriverInventory to return true (build needed) - no inventory path set
 			// This will cause checkDriverInventory to return true
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock buildDriverFromSource failure - Ubuntu specific arguments
+		// Mock buildDriverFromSource failure - Ubuntu specific arguments
 			expectedError := errors.New("install.pl failed")
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
@@ -1468,27 +1476,28 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
-			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+		// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
+		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock buildDriverFromSource - Ubuntu specific arguments
-			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-				"--without-xpmem", "--without-xpmem-modules",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+		// Mock buildDriverFromSource - Ubuntu specific arguments
+		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+			"--without-xpmem", "--without-xpmem-modules",
+			"--without-mlnx-nfsrdma-modules",
+			"--without-mlnx-nvme-modules").Return("", "", nil)
 
-			// Mock copyBuildArtifacts failure - debug logging and copy failure
+		// Mock copyBuildArtifacts failure - debug logging and copy failure
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.MatchedBy(func(cmd string) bool {
 				return strings.Contains(cmd, "ls -la") && strings.Contains(cmd, "DEBS")
@@ -1520,28 +1529,29 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
 			// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
-			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock buildDriverFromSource - Ubuntu specific arguments
-			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-				"--without-xpmem", "--without-xpmem-modules",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+		// Mock buildDriverFromSource - Ubuntu specific arguments
+		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+			"--without-xpmem", "--without-xpmem-modules",
+			"--without-mlnx-nfsrdma-modules",
+			"--without-mlnx-nvme-modules").Return("", "", nil)
 
-			// Mock copyBuildArtifacts - debug logging and copy
-			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil).Times(4)
+		// Mock copyBuildArtifacts - debug logging and copy
+		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil).Times(4)
 
 			// Mock fixSourceLink
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
@@ -1565,38 +1575,39 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			// This will cause checkDriverInventory to return true
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		// This will cause checkDriverInventory to return true
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock buildDriverFromSource - Ubuntu specific arguments
-			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-				"--without-xpmem", "--without-xpmem-modules",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+		// Mock buildDriverFromSource - Ubuntu specific arguments
+		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+			"--without-xpmem", "--without-xpmem-modules",
+			"--without-mlnx-nfsrdma-modules",
+			"--without-mlnx-nvme-modules").Return("", "", nil)
 
-			// Mock copyBuildArtifacts - debug logging and copy
-			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
+		// Mock copyBuildArtifacts - debug logging and copy
+		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
 
-			// Note: storeBuildChecksum is not called when NvidiaNicDriversInventoryPath is empty
+		// Note: storeBuildChecksum is not called when NvidiaNicDriversInventoryPath is empty
 
-			// Mock fixSourceLink failure (should not cause build to fail)
-			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-			expectedError := errors.New("readlink failed")
+		// Mock fixSourceLink failure (should not cause build to fail)
+		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+		expectedError := errors.New("readlink failed")
 			osMock.EXPECT().Readlink(mock.Anything).Return("", expectedError)
 
 			// Mock installDriver - check if kernel modules directory exists
@@ -1642,44 +1653,45 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-			// Mock checkDriverInventory to return true (build needed) - no inventory path set
-			// This will cause checkDriverInventory to return true
+		// Mock checkDriverInventory to return true (build needed) - no inventory path set
+		// This will cause checkDriverInventory to return true
+		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-			// Mock createInventoryDirectory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+		// Mock createInventoryDirectory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-			// Mock installUbuntuPrerequisites
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+		// Mock installUbuntuPrerequisites
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-			// Mock buildDriverFromSource - Ubuntu specific arguments
-			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-				"--without-xpmem", "--without-xpmem-modules",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+		// Mock buildDriverFromSource - Ubuntu specific arguments
+		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+			"--without-xpmem", "--without-xpmem-modules",
+			"--without-mlnx-nfsrdma-modules",
+			"--without-mlnx-nvme-modules").Return("", "", nil)
 
-			// Mock copyBuildArtifacts - debug logging and copy
-			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
-			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
+		// Mock copyBuildArtifacts - debug logging and copy
+		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
+		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
 
-			// Mock fixSourceLink
-			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-			osMock.EXPECT().Readlink(mock.Anything).Return("", errors.New("not found"))
+		// Mock fixSourceLink
+		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+		osMock.EXPECT().Readlink(mock.Anything).Return("", errors.New("not found"))
 
-			// Mock installDriver - check if kernel modules directory exists
-			osMock.EXPECT().Stat("/lib/modules/5.4.0-42-generic").Return(nil, os.ErrNotExist)
-			// Mock creating kernel modules directory
-			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", "/lib/modules/5.4.0-42-generic").Return("", "", nil)
-			// Mock creating modules.order and modules.builtin files
-			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.order").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.builtin").Return("", "", nil)
+		// Mock installDriver - check if kernel modules directory exists
+		osMock.EXPECT().Stat("/lib/modules/5.4.0-42-generic").Return(nil, os.ErrNotExist)
+		// Mock creating kernel modules directory
+		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", "/lib/modules/5.4.0-42-generic").Return("", "", nil)
+		// Mock creating modules.order and modules.builtin files
+		cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.order").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.builtin").Return("", "", nil)
 			// Mock Ubuntu driver installation
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil)
@@ -1872,6 +1884,69 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 			Expect(dm.newDriverLoaded).To(BeFalse())
+		})
+
+		It("should skip dkms build/install when DtkOcpDriverBuild is true (kmod packages place modules)", func() {
+			cfg.UseDKMS = true
+			cfg.DtkOcpDriverBuild = true
+			dm = &driverMgr{
+				cfg:  cfg,
+				cmd:  cmdMock,
+				host: hostMock,
+				os:   osMock,
+			}
+
+			// Mock generateOfedModulesBlacklist
+			blacklistFile, err := os.CreateTemp(tempDir, "blacklist")
+			Expect(err).NotTo(HaveOccurred())
+			osMock.EXPECT().Create(cfg.OfedBlacklistModulesFile).Return(blacklistFile, nil)
+			osMock.EXPECT().Stat(cfg.OfedBlacklistModulesFile).Return(nil, nil)
+			osMock.EXPECT().RemoveAll(cfg.OfedBlacklistModulesFile).Return(nil)
+
+			// DKMS setup for DTK path: discovers module, checks status, does dkms add —
+			// then returns early without dkms build or dkms install.
+			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.14.0-570.78.1.el9_6.x86_64", nil)
+			mockEntry := mockDirEntry{name: "mlnx-ofa_kernel-2604.0.43-1", isDir: true}
+			osMock.EXPECT().ReadDir("/usr/src/").Return([]os.DirEntry{mockEntry}, nil)
+			osMock.EXPECT().Stat("/usr/src/mlnx-ofa_kernel-2604.0.43-1/dkms.conf").Return(nil, nil)
+			osMock.EXPECT().ReadFile("/usr/src/mlnx-ofa_kernel-2604.0.43-1/dkms.conf").
+				Return([]byte("PACKAGE_NAME=\"mlnx-ofa_kernel\"\nPACKAGE_VERSION=\"2604.0.43-1\"\n"), nil)
+			// Not yet installed — triggers dkms add path
+			cmdMock.EXPECT().RunCommand(ctx, "dkms", "status", "mlnx-ofa_kernel", "2604.0.43-1").Return("", "", nil)
+			// dkms add status check (already added check inside dkmsAdd)
+			cmdMock.EXPECT().RunCommand(ctx, "dkms", "status", "mlnx-ofa_kernel", "2604.0.43-1").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "dkms", "add", "-m", "mlnx-ofa_kernel", "-v", "2604.0.43-1").Return("", "", nil)
+			// dkms build and dkms install must NOT be called (DTK path returns after dkms add)
+
+			// Mock checkLoadedKmodSrcverVsModinfo — modules match
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
+				"mlx5_core": {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
+				"mlx5_ib":   {Name: "mlx5_ib", RefCount: 1, UsedBy: []string{}},
+				"ib_core":   {Name: "ib_core", RefCount: 1, UsedBy: []string{}},
+			}, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_core").Return("srcversion: ABC123", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cat", "/sys/module/mlx5_core/srcversion").Return("ABC123", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_ib").Return("srcversion: DEF456", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cat", "/sys/module/mlx5_ib/srcversion").Return("DEF456", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "ib_core").Return("srcversion: GHI789", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cat", "/sys/module/ib_core/srcversion").Return("GHI789", "", nil)
+
+			// Mock printLoadedDriverVersion
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
+				"mlx5_core": {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
+			}, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ls", "/sys/class/net/").Return("eth0", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "/sys/class/net/eth0/device/driver").Return("../../../../bus/pci/drivers/mlx5_core", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ethtool", "--driver", "eth0").Return("version: 5.0-1.0.0", "", nil)
+
+			// Mock mountRootfs
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+
+			result, err := dm.Load(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
 		})
 
 		It("should restart driver when modules don't match", func() {
@@ -4195,5 +4270,165 @@ var _ = Describe("Driver OFED Blacklist", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(os.IsNotExist(err)).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("Driver DTK setup", func() {
+	var (
+		cmdMock *cmdMockPkg.Interface
+		ctx     context.Context
+		tempDir string
+	)
+
+	BeforeEach(func() {
+		cmdMock = cmdMockPkg.NewInterface(GinkgoT())
+		ctx = context.Background()
+		tempDir = GinkgoT().TempDir()
+	})
+
+	Context("dtkSetupDriverBuild dtk.env generation", func() {
+		// mockCpCalls sets up the three RunCommand expectations for the cp invocations
+		// inside dtkSetupDriverBuild (driver sources, entrypoint binary, build script).
+		mockCpCalls := func(dm *driverMgr, sharedDir string) {
+			srcDir := dm.cfg.NvidiaNicDriverPath
+			destDir := filepath.Join(sharedDir, "MLNX_OFED_SRC-"+dm.cfg.NvidiaNicDriverVer)
+			cmdMock.EXPECT().RunCommand(mock.Anything, "cp", "-rT", srcDir, destDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(mock.Anything, "cp", "/root/entrypoint",
+				filepath.Join(sharedDir, "entrypoint")).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(mock.Anything, "cp", constants.DtkOcpBuildScriptPath,
+				filepath.Join(sharedDir, filepath.Base(constants.DtkOcpBuildScriptPath))).Return("", "", nil)
+		}
+
+		It("should write USE_DKMS=true into dtk.env when UseDKMS is true", func() {
+			cfg := config.Config{
+				NvidiaNicDriverVer:  "26.04-0.5.3.0",
+				NvidiaNicDriverPath: "/run/mellanox/src/MLNX_OFED_SRC-26.04-0.5.3.0",
+				UseDKMS:             true,
+				EnableNfsRdma:       true,
+			}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+
+			sharedDir := filepath.Join(tempDir, "dkms-true")
+			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
+			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+
+			mockCpCalls(dm, sharedDir)
+
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="true"`))
+			// Sanity-check that other required fields are also present
+			Expect(string(content)).To(ContainSubstring(`export USE_NEW_ENTRYPOINT="true"`))
+			Expect(string(content)).To(ContainSubstring(`export NVIDIA_NIC_DRIVER_VER="26.04-0.5.3.0"`))
+		})
+
+		It("should write USE_DKMS=false into dtk.env when UseDKMS is false", func() {
+			cfg := config.Config{
+				NvidiaNicDriverVer:  "26.04-0.5.3.0",
+				NvidiaNicDriverPath: "/run/mellanox/src/MLNX_OFED_SRC-26.04-0.5.3.0",
+				UseDKMS:             false,
+				EnableNfsRdma:       true,
+			}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+
+			sharedDir := filepath.Join(tempDir, "dkms-false")
+			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
+			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+
+			mockCpCalls(dm, sharedDir)
+
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="false"`))
+		})
+	})
+})
+
+var _ = Describe("discoverDKMSModuleIn", func() {
+	const dkmsConf = `PACKAGE_NAME="mlnx-ofa_kernel"
+PACKAGE_VERSION="2604.0.43-1"
+`
+
+	var (
+		dm      *driverMgr
+		ctx     context.Context
+		srcBase string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		srcBase = GinkgoT().TempDir()
+		dm = &driverMgr{os: wrappers.NewOS()}
+	})
+
+	It("finds dkms.conf directly under mlnx-ofa_kernel-* directory", func() {
+		dir := filepath.Join(srcBase, "mlnx-ofa_kernel-2604.0.43-1")
+		Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(dir, "dkms.conf"), []byte(dkmsConf), 0644)).To(Succeed())
+
+		name, version, err := dm.discoverDKMSModuleIn(ctx, srcBase)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("mlnx-ofa_kernel"))
+		Expect(version).To(Equal("2604.0.43-1"))
+	})
+
+	It("finds dkms.conf via a symlink to source directory (OFED 26.04 layout)", func() {
+		// Simulate: /usr/src/ofa_kernel-2604.0.43-1/source/dkms.conf
+		//           /usr/src/mlnx-ofa_kernel-2604.0.43-1 -> ofa_kernel-2604.0.43-1/source
+		realDir := filepath.Join(srcBase, "ofa_kernel-2604.0.43-1", "source")
+		Expect(os.MkdirAll(realDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(realDir, "dkms.conf"), []byte(dkmsConf), 0644)).To(Succeed())
+		Expect(os.Symlink(realDir, filepath.Join(srcBase, "mlnx-ofa_kernel-2604.0.43-1"))).To(Succeed())
+
+		name, version, err := dm.discoverDKMSModuleIn(ctx, srcBase)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("mlnx-ofa_kernel"))
+		Expect(version).To(Equal("2604.0.43-1"))
+	})
+
+	It("finds dkms.conf nested under source/ subdirectory", func() {
+		// Simulate: /usr/src/ofa_kernel-2604.0.43-1/source/dkms.conf (no symlink)
+		sourceDir := filepath.Join(srcBase, "ofa_kernel-2604.0.43-1", "source")
+		Expect(os.MkdirAll(sourceDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(sourceDir, "dkms.conf"), []byte(dkmsConf), 0644)).To(Succeed())
+
+		name, version, err := dm.discoverDKMSModuleIn(ctx, srcBase)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("mlnx-ofa_kernel"))
+		Expect(version).To(Equal("2604.0.43-1"))
+	})
+
+	It("prefers mlnx-ofa_kernel-* over other directories", func() {
+		// Place a generic module first
+		genericDir := filepath.Join(srcBase, "some-other-module-1.0")
+		Expect(os.MkdirAll(genericDir, 0755)).To(Succeed())
+		genericConf := `PACKAGE_NAME="some-other-module"
+PACKAGE_VERSION="1.0"
+`
+		Expect(os.WriteFile(filepath.Join(genericDir, "dkms.conf"), []byte(genericConf), 0644)).To(Succeed())
+
+		// Place mlnx-ofa_kernel-* after
+		mlnxDir := filepath.Join(srcBase, "mlnx-ofa_kernel-2604.0.43-1")
+		Expect(os.MkdirAll(mlnxDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(mlnxDir, "dkms.conf"), []byte(dkmsConf), 0644)).To(Succeed())
+
+		name, version, err := dm.discoverDKMSModuleIn(ctx, srcBase)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("mlnx-ofa_kernel"))
+		Expect(version).To(Equal("2604.0.43-1"))
+	})
+
+	It("returns error when no dkms.conf found anywhere", func() {
+		Expect(os.MkdirAll(filepath.Join(srcBase, "some-dir"), 0755)).To(Succeed())
+
+		_, _, err := dm.discoverDKMSModuleIn(ctx, srcBase)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no DKMS module found"))
 	})
 })

--- a/entrypoint/internal/dtk/build.go
+++ b/entrypoint/internal/dtk/build.go
@@ -96,9 +96,17 @@ func RunBuild(ctx context.Context, log logr.Logger, cfg config.Config, cmdHelper
 		"--with-mlnx-tools",
 		"--with-ofed-scripts",
 		"--copy-ifnames-udev",
-		"--disable-kmp",
-		"--without-dkms",
 	}
+
+	if !cfg.UseDKMS {
+		// Non-DKMS path: suppress DKMS source packages and produce only static
+		// kernel module packages (kmod-*).
+		installArgs = append(installArgs, "--disable-kmp", "--without-dkms")
+	}
+	// DKMS path (UseDKMS=true): neither --without-dkms nor --disable-kmp so that
+	// install.pl produces both the DKMS source package (for dkms add registration in
+	// the main container) and pre-compiled kmod binary packages (which the main
+	// container installs to place .ko files without needing kernel headers).
 
 	if cfg.AppendDriverBuildFlags != "" {
 		// Use shell-style parsing to handle quoted arguments correctly

--- a/entrypoint/internal/dtk/build_test.go
+++ b/entrypoint/internal/dtk/build_test.go
@@ -32,6 +32,7 @@ import (
 	cmdMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
 )
 
+
 func TestRunBuild(t *testing.T) {
 	log := logr.Discard()
 	tempDir := t.TempDir()
@@ -71,7 +72,10 @@ func TestRunBuild(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to install build dependencies")
 	})
 
-	t.Run("should wait for start flag and run build", func(t *testing.T) {
+	t.Run("should wait for start flag and run build without dkms", func(t *testing.T) {
+		cfgNoDKMS := cfg
+		cfgNoDKMS.UseDKMS = false
+
 		cmdMock := cmdMockPkg.NewInterface(t)
 		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "perl").Return("", "", nil)
 		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "ethtool", "autoconf", "pciutils", "automake", "libtool", "python3-devel").Return("", "", nil)
@@ -85,36 +89,81 @@ func TestRunBuild(t *testing.T) {
 		}()
 
 		expectedInstallScript := filepath.Join(tempDir, "MLNX_OFED_SRC-1.0.0", "install.pl")
+		// --without-dkms must be present when UseDKMS is false
 		cmdMock.EXPECT().RunCommand(mock.Anything, expectedInstallScript,
 			"--build-only", "--kernel-only", "--without-knem", "--without-iser", "--without-isert",
 			"--without-srp", "--with-mlnx-tools", "--with-ofed-scripts", "--copy-ifnames-udev",
 			"--disable-kmp", "--without-dkms").Return("", "", nil)
 
-		// Create a context that we can cancel to simulate end of execution
 		ctx, cancel := context.WithCancel(context.Background())
-		
-		// Run in a goroutine so we can cancel it
 		errCh := make(chan error)
 		go func() {
-			errCh <- RunBuild(ctx, log, cfg, cmdMock)
+			errCh <- RunBuild(ctx, log, cfgNoDKMS, cmdMock)
 		}()
 
-		// Wait for done flag to be created
-		// Increased timeout to account for retryDelay in RunBuild
 		assert.Eventually(t, func() bool {
 			_, err := os.Stat(doneFlag)
 			return err == nil
 		}, 5*time.Second, 100*time.Millisecond)
 
-		// Wait for start flag to be removed
 		assert.Eventually(t, func() bool {
 			_, err := os.Stat(startFlag)
 			return os.IsNotExist(err)
 		}, 5*time.Second, 100*time.Millisecond)
 
-		// Cancel context to stop the infinite loop
 		cancel()
-		
+		err := <-errCh
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("should not pass --without-dkms or --disable-kmp when UseDKMS is true", func(t *testing.T) {
+		cfgDKMS := cfg
+		cfgDKMS.UseDKMS = true
+
+		// Use a fresh set of flag files to avoid state from the previous sub-test.
+		startFlagDKMS := filepath.Join(tempDir, "dtk_start_compile_dkms")
+		doneFlagDKMS := filepath.Join(tempDir, "dtk_done_compile_dkms")
+		cfgDKMS.DtkOcpStartCompileFlag = startFlagDKMS
+		cfgDKMS.DtkOcpDoneCompileFlag = doneFlagDKMS
+
+		cmdMock := cmdMockPkg.NewInterface(t)
+		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "perl").Return("", "", nil)
+		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "ethtool", "autoconf", "pciutils", "automake", "libtool", "python3-devel").Return("", "", nil)
+
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			f, err := os.Create(startFlagDKMS)
+			assert.NoError(t, err)
+			f.Close()
+		}()
+
+		expectedInstallScript := filepath.Join(tempDir, "MLNX_OFED_SRC-1.0.0", "install.pl")
+		// When UseDKMS=true, neither --without-dkms nor --disable-kmp should be passed.
+		// This causes install.pl to produce both a DKMS source package (for dkms add
+		// registration in the main container) and pre-compiled kmod binary packages
+		// (which place .ko files without needing kernel headers in the main container).
+		cmdMock.EXPECT().RunCommand(mock.Anything, expectedInstallScript,
+			"--build-only", "--kernel-only", "--without-knem", "--without-iser", "--without-isert",
+			"--without-srp", "--with-mlnx-tools", "--with-ofed-scripts", "--copy-ifnames-udev").
+			Return("", "", nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error)
+		go func() {
+			errCh <- RunBuild(ctx, log, cfgDKMS, cmdMock)
+		}()
+
+		assert.Eventually(t, func() bool {
+			_, err := os.Stat(doneFlagDKMS)
+			return err == nil
+		}, 5*time.Second, 100*time.Millisecond)
+
+		assert.Eventually(t, func() bool {
+			_, err := os.Stat(startFlagDKMS)
+			return os.IsNotExist(err)
+		}, 5*time.Second, 100*time.Millisecond)
+
+		cancel()
 		err := <-errCh
 		assert.ErrorIs(t, err, context.Canceled)
 	})


### PR DESCRIPTION
The DTK build script unconditionally passed --without-dkms to install.pl, so the driver inventory never contained *-dkms-* source packages regardless of the USE_DKMS setting. On containers configured with USE_DKMS=true the entrypoint would then crash-loop with "no DKMS module found in /usr/src/" because SetupDKMS found nothing to register.

Make --without-dkms conditional on !cfg.UseDKMS so that when DKMS is requested, install.pl produces the DKMS source packages that populate /usr/src/ and allow SetupDKMS to succeed.