### PR TITLE
feat: add ubuntu26.04 support to 26.07 release manifest

### DIFF
--- a/release_manifests/26.07.yaml
+++ b/release_manifests/26.07.yaml
@@ -22,6 +22,10 @@ precompiled:
   - 6.8.0-1055-nvidia
   - 6.8.0-1057-aws
 dynamically_compiled:
+- os: ubuntu26.04
+  archs:
+  - amd64
+  - arm64
 - os: ubuntu24.04-stig
   archs:
   - amd64


### PR DESCRIPTION
Add ubuntu26.04 (amd64, arm64) to the dynamically_compiled section.