### PR TITLE
chore: bump Go to 1.26 and update tooling

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
       - name: checkout
         uses: actions/checkout@v7
       - name: lint
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
       - name: checkout
         uses: actions/checkout@v7
       - name: check go modules
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
       - name: checkout
         uses: actions/checkout@v7
       - name: test

--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -22,7 +22,7 @@ ARG D_PYTHON="python${D_PYTHON_VERSION}"
 
 ##################################################################
 # Stage: build go binary for entrypoint
-FROM golang:1.25 AS go_builder
+FROM golang:1.26 AS go_builder
 
 # Set GOPROXY if provided
 ARG GOPROXY

--- a/SLES_Dockerfile
+++ b/SLES_Dockerfile
@@ -14,7 +14,7 @@ ARG D_BASE_IMAGE="registry.suse.com/suse/sle15:15.5"
 
 ##################################################################
 # Stage: build go binary for entrypoint
-FROM golang:1.25 AS go_builder
+FROM golang:1.26 AS go_builder
 
 # Set GOPROXY if provided
 ARG GOPROXY

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -15,7 +15,7 @@ ARG D_BASE_IMAGE="ubuntu:22.04"
 
 ##################################################################
 # Stage: build go binary for entrypoint
-FROM golang:1.25 AS go_builder
+FROM golang:1.26 AS go_builder
 
 # Set GOPROXY if provided
 ARG GOPROXY

--- a/entrypoint/.golangci.yaml
+++ b/entrypoint/.golangci.yaml
@@ -25,7 +25,7 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet

--- a/entrypoint/Makefile
+++ b/entrypoint/Makefile
@@ -51,12 +51,12 @@ $(MOCKERY): | $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/vektra/mockery/v2@$(MOCKERY_VERSION)
 
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.2
 .PHONY: golangci-lint ## Download golangci-lint locally if necessary.
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) $(GOLANGCI_LINT_VERSION) ;\
 	}
 
 ##@ General

--- a/entrypoint/cmd/main.go
+++ b/entrypoint/cmd/main.go
@@ -38,6 +38,8 @@ import (
 	"github.com/Mellanox/doca-driver-build/entrypoint/internal/version"
 )
 
+const stderrOutput = "stderr"
+
 type ctxData struct {
 	//nolint:containedctx
 	Ctx    context.Context
@@ -129,8 +131,8 @@ func getLogger(cfg config.Config) logr.Logger {
 		Encoding:          "console",
 		DisableStacktrace: true,
 		EncoderConfig:     zap.NewDevelopmentEncoderConfig(),
-		OutputPaths:       []string{"stderr"},
-		ErrorOutputPaths:  []string{"stderr"},
+		OutputPaths:       []string{stderrOutput},
+		ErrorOutputPaths:  []string{stderrOutput},
 	}
 
 	if cfg.EntrypointDebug {

--- a/entrypoint/go.mod
+++ b/entrypoint/go.mod
@@ -1,6 +1,6 @@
 module github.com/Mellanox/doca-driver-build/entrypoint
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -39,6 +39,11 @@ const (
 	kernelTypeStandard = "standard"
 	kernelTypeRT       = "rt"
 	kernelType64k      = "64k"
+
+	flagDisableKMP = "--disable-kmp"
+	dnfCmd         = "dnf"
+	dnfFlagQuiet   = "-q"
+	dnfFlagYes     = "-y"
 )
 
 // New creates a new instance of the driver manager
@@ -728,12 +733,12 @@ func (d *driverMgr) installGCCRedHat(ctx context.Context, majorVersion int) (str
 	log.V(1).Info("Checking for gcc-toolset availability", "package", toolsetPackage)
 
 	// Check if gcc-toolset is available
-	_, _, err := d.cmd.RunCommand(ctx, "dnf", "list", "available", toolsetPackage)
+	_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "list", "available", toolsetPackage)
 	if err == nil {
 		// gcc-toolset version is available
 		kernelGCCVer := fmt.Sprintf("gcc-toolset-%d-gcc", majorVersion)
 		log.V(1).Info("Installing gcc-toolset for RedHat", "package", toolsetPackage)
-		_, _, err = d.cmd.RunCommand(ctx, "dnf", "-q", "-y", "install", toolsetPackage)
+		_, _, err = d.cmd.RunCommand(ctx, dnfCmd, dnfFlagQuiet, dnfFlagYes, "install", toolsetPackage)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to install %s: %w", toolsetPackage, err)
 		}
@@ -744,7 +749,7 @@ func (d *driverMgr) installGCCRedHat(ctx context.Context, majorVersion int) (str
 	// Fall back to default gcc package
 	log.V(1).Info("gcc-toolset not available, using default gcc package")
 	kernelGCCVer := "gcc"
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "-q", "-y", "install", "gcc")
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, dnfFlagQuiet, dnfFlagYes, "install", "gcc")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to install gcc: %w", err)
 	}
@@ -1143,7 +1148,7 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 	switch osType {
 	case constants.OSTypeUbuntu:
-		flags := []string{"--disable-kmp"}
+		flags := []string{flagDisableKMP}
 		// Conditionally add --without-dkms based on config
 		// If UseDKMS is true, we want install.pl to create DKMS packages
 		if !d.cfg.UseDKMS {
@@ -1152,7 +1157,7 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 		return flags
 	case constants.OSTypeSLES:
 		flags := []string{
-			"--disable-kmp",
+			flagDisableKMP,
 		}
 		// Conditionally add --without-dkms based on config (must come before --kernel-sources)
 		if !d.cfg.UseDKMS {
@@ -1163,7 +1168,7 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 		)
 		return flags
 	case constants.OSTypeRedHat:
-		flags := []string{"--disable-kmp"}
+		flags := []string{flagDisableKMP}
 		// Conditionally add --without-dkms based on config
 		if !d.cfg.UseDKMS {
 			flags = append(flags, "--without-dkms")
@@ -1508,16 +1513,16 @@ func (d *driverMgr) setupOpenShiftRepositories(ctx context.Context, versionInfo 
 
 	// Enable RHOCP repository
 	repoName := fmt.Sprintf("rhocp-%s-for-rhel-%d-%s-rpms", versionInfo.OpenShiftVersion, versionInfo.MajorVersion, arch)
-	_, _, err := d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-enabled", repoName)
+	_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-enabled", repoName)
 	if err != nil {
 		log.V(1).Info("Failed to enable RHOCP repository, continuing", "repo", repoName, "error", err)
 	}
 
 	// Test if makecache works
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "makecache", "--releasever="+versionInfo.FullVersion)
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, "makecache", "--releasever="+versionInfo.FullVersion)
 	if err != nil {
 		log.V(1).Info("Makecache failed, disabling RHOCP repository", "error", err)
-		_, _, _ = d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-disabled", repoName)
+		_, _, _ = d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-disabled", repoName)
 	}
 }
 
@@ -1533,7 +1538,7 @@ func (d *driverMgr) setupEUSRepositories(ctx context.Context, versionInfo *host.
 		if versionInfo.FullVersion == version {
 			log.V(1).Info("Enabling EUS repository", "version", version, "arch", arch)
 			repoName := fmt.Sprintf("rhel-%d-for-%s-baseos-eus-rpms", versionInfo.MajorVersion, arch)
-			_, _, err := d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-enabled", repoName)
+			_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-enabled", repoName)
 			if err != nil {
 				log.V(1).Info("Failed to enable EUS repository", "repo", repoName, "error", err)
 			}
@@ -1573,7 +1578,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 		}
 
 		for _, pkg := range packages {
-			args := []string{"dnf", "-q", "-y"}
+			args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 			if releaseverStr != "" {
 				args = append(args, releaseverStr)
 			}
@@ -1586,7 +1591,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 		}
 
 		// Install kernel-devel with --allowerasing flag
-		args := []string{"dnf", "-q", "-y"}
+		args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 		if releaseverStr != "" {
 			args = append(args, releaseverStr)
 		}
@@ -1599,7 +1604,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 	}
 
 	// Install kernel development and modules packages
-	args := []string{"dnf", "-q", "-y"}
+	args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 	if releaseverStr != "" {
 		args = append(args, releaseverStr)
 	}
@@ -1974,7 +1979,7 @@ func (d *driverMgr) installRedHatDependencies(ctx context.Context, versionInfo *
 	}
 
 	args := make([]string, 0, 5+len(packages))
-	args = append(args, "dnf", "-q", "-y", "--releasever="+versionInfo.FullVersion, "install")
+	args = append(args, dnfCmd, dnfFlagQuiet, dnfFlagYes, "--releasever="+versionInfo.FullVersion, "install")
 	args = append(args, packages...)
 
 	_, _, err := d.cmd.RunCommand(ctx, args[0], args[1:]...)
@@ -1983,12 +1988,12 @@ func (d *driverMgr) installRedHatDependencies(ctx context.Context, versionInfo *
 	}
 
 	// Test makecache and disable EUS if it fails
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "makecache", "--releasever="+versionInfo.FullVersion)
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, "makecache", "--releasever="+versionInfo.FullVersion)
 	if err != nil {
 		log.V(1).Info("Makecache failed, disabling EUS repository", "error", err)
 		arch := d.getArchitecture(ctx)
 		repoName := fmt.Sprintf("rhel-%d-for-%s-baseos-eus-rpms", versionInfo.MajorVersion, arch)
-		_, _, _ = d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-disabled", repoName)
+		_, _, _ = d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-disabled", repoName)
 	}
 
 	return nil


### PR DESCRIPTION
- go.mod: set go 1.26.0
- Dockerfiles (RHEL, SLES, Ubuntu): update base image to golang:1.26
- .github/workflows/checks.yaml: set go-version to 1.26.x in all jobs
- entrypoint/Makefile: bump golangci-lint to v2.12.2; pin install.sh to the release tag instead of master to avoid checksum mismatches
- entrypoint/.golangci.yaml: replace deprecated gomodguard with gomodguard_v2 (deprecated since golangci-lint v2.12.0)
- entrypoint/internal/driver/driver.go: extract dnfCmd, dnfFlagQuiet, dnfFlagYes, flagDisableKMP constants to satisfy goconst linter
- entrypoint/cmd/main.go: extract stderrOutput constant to satisfy goconst linter