### PR TITLE
fix: always remount shared kernel headers to avoid stale nv-peer-mem …

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -202,7 +202,18 @@ function mount_rootfs() {
     exec_cmd mount --make-runbindable /sys
     exec_cmd mount --make-private /sys
 
-    (mount -l | grep mellanox | grep -v tmpfs -q) && debug_print "Mount ${MLX_DRIVERS_MOUNT} exists" && return
+    # A mount at MLX_DRIVERS_MOUNT may already be present from a previous container
+    # instance that terminated without running termination_handler (e.g. killed
+    # rather than gracefully stopped). Such a mount is bound to that old container's
+    # filesystem snapshot, not the driver this process just (re)built, so it must
+    # never be trusted as-is: unmount it (best effort) and always recreate it fresh
+    # below, rather than skipping the mount when one is merely present.
+    if mount -l | grep mellanox | grep -v tmpfs -q; then
+        debug_print "Found existing mount ${MLX_DRIVERS_MOUNT}, unmounting before remount to avoid stale content"
+        if ! umount_output=$(umount -l -R ${MLX_DRIVERS_MOUNT}${SHARED_KERNEL_HEADERS_DIR} 2>&1); then
+            debug_print "Failed to unmount existing mount ${MLX_DRIVERS_MOUNT}${SHARED_KERNEL_HEADERS_DIR}, proceeding to remount anyway: ${umount_output}"
+        fi
+    fi
 
     exec_cmd mkdir -p ${MLX_DRIVERS_MOUNT}${SHARED_KERNEL_HEADERS_DIR}
     exec_cmd mount --rbind ${SHARED_KERNEL_HEADERS_DIR} ${MLX_DRIVERS_MOUNT}${SHARED_KERNEL_HEADERS_DIR}

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -446,21 +446,32 @@ func (d *driverMgr) mountRootfs(ctx context.Context) error {
 		return fmt.Errorf("failed to make /sys private: %w, stderr: %s", err, stderr)
 	}
 
-	// Check if mount already exists
+	mountPath := filepath.Join(d.cfg.MlxDriversMount, d.cfg.SharedKernelHeadersDir)
+
+	// A mount at mountPath may already be present from a previous container instance
+	// that terminated without running its cleanup handler (e.g. killed rather than
+	// gracefully stopped). Such a mount is bound to that old container's filesystem
+	// snapshot, not the driver this process just (re)built, so it must never be
+	// trusted as-is: unmount it (best effort) and always recreate it fresh below,
+	// rather than skipping the mount when one is merely present.
 	stdout, _, err := d.cmd.RunCommand(ctx, "mount", "-l")
 	if err == nil {
 		// Check if mellanox mount exists (excluding tmpfs)
 		lines := strings.Split(stdout, "\n")
 		for _, line := range lines {
 			if strings.Contains(line, "mellanox") && !strings.Contains(line, "tmpfs") {
-				log.V(1).Info("Mount already exists", "mount", d.cfg.MlxDriversMount)
-				return nil
+				log.V(1).Info("Found existing mount, unmounting before remount to avoid stale content",
+					"mount", d.cfg.MlxDriversMount)
+				if _, umountStderr, umountErr := d.cmd.RunCommand(ctx, "umount", "-l", "-R", mountPath); umountErr != nil {
+					log.V(1).Info("Failed to unmount existing mount, proceeding to remount anyway",
+						"error", umountErr, "stderr", umountStderr)
+				}
+				break
 			}
 		}
 	}
 
 	// Create mount directory
-	mountPath := filepath.Join(d.cfg.MlxDriversMount, d.cfg.SharedKernelHeadersDir)
 	if err := d.os.MkdirAll(mountPath, 0o755); err != nil {
 		return fmt.Errorf("failed to create mount directory %s: %w", mountPath, err)
 	}

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -1726,6 +1726,12 @@ var _ = Describe("Driver", func() {
 		})
 
 		It("should return true when modules match and no restart is needed", func() {
+			// This test exercises the real OS wrapper for mountRootfs's MkdirAll call,
+			// so point the mount config at a real (temp) directory rather than the
+			// zero-value paths used elsewhere in this context.
+			dm.cfg.MlxDriversMount = tempDir
+			dm.cfg.SharedKernelHeadersDir = "/mnt-src/"
+
 			// Mock checkLoadedKmodSrcverVsModinfo to return true (modules match)
 			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
 				"mlx5_core": {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
@@ -1750,9 +1756,12 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "ethtool", "--driver", "eth0").Return("version: 5.0-1.0.0", "", nil)
 
 			// Mock mountRootfs (mount already exists scenario)
+			mountPath := filepath.Join(tempDir, "mnt-src")
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", mountPath).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "/mnt-src/", mountPath).Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -1816,6 +1825,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -1879,6 +1891,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -1943,6 +1958,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -1996,6 +2014,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2056,6 +2077,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2167,6 +2191,9 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return("/usr/src/ on /run/mellanox/drivers/usr/src/ type none", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "").Return("", "", nil)
+			osMock.EXPECT().MkdirAll("", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "", "").Return("", "", nil)
 
 			result, err := dm.Load(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -3082,7 +3109,7 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should skip mount when mellanox mount already exists", func() {
+		It("should unmount stale mount and remount when mellanox mount already exists", func() {
 			cfg.MlxDriversMount = "/run/mellanox/drivers"
 			cfg.SharedKernelHeadersDir = "/usr/src/"
 			dm = New(constants.DriverContainerModePrecompiled, cfg, cmdMock, hostMock, osMock).(*driverMgr)
@@ -3093,11 +3120,39 @@ var _ = Describe("Driver", func() {
 			// Mock mount --make-private /sys
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
 
-			// Mock mount -l to check if mount exists (returns existing mellanox mount)
+			// Mock mount -l to check if mount exists (returns existing mellanox mount,
+			// which may be stale leftover from a previous, non-gracefully-terminated container)
 			mountOutput := "/dev/sda1 on / type ext4 (rw,relatime)\n/usr/src/ on /run/mellanox/drivers/usr/src/ type none (rw,relatime)\n"
 			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return(mountOutput, "", nil)
 
-			// Should not call mkdir or mount --rbind when mount exists
+			// Should unmount the existing (possibly stale) mount before recreating it
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "/run/mellanox/drivers/usr/src").Return("", "", nil)
+
+			// Should still (re)create the mount directory and rbind mount fresh
+			osMock.EXPECT().MkdirAll("/run/mellanox/drivers/usr/src", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "/usr/src/", "/run/mellanox/drivers/usr/src").Return("", "", nil)
+
+			err := dm.mountRootfs(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should proceed with remount even when unmounting the stale mount fails", func() {
+			cfg.MlxDriversMount = "/run/mellanox/drivers"
+			cfg.SharedKernelHeadersDir = "/usr/src/"
+			dm = New(constants.DriverContainerModePrecompiled, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-runbindable", "/sys").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--make-private", "/sys").Return("", "", nil)
+
+			mountOutput := "/dev/sda1 on / type ext4 (rw,relatime)\n/usr/src/ on /run/mellanox/drivers/usr/src/ type none (rw,relatime)\n"
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "-l").Return(mountOutput, "", nil)
+
+			// Unmount failure should be logged and not block the remount
+			cmdMock.EXPECT().RunCommand(ctx, "umount", "-l", "-R", "/run/mellanox/drivers/usr/src").
+				Return("", "target is busy", errors.New("umount failed"))
+
+			osMock.EXPECT().MkdirAll("/run/mellanox/drivers/usr/src", os.FileMode(0o755)).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mount", "--rbind", "/usr/src/", "/run/mellanox/drivers/usr/src").Return("", "", nil)
 
 			err := dm.mountRootfs(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -4441,12 +4496,12 @@ var _ = Describe("Unload", func() {
 	)
 
 	var (
-		dm      *driverMgr
-		cmdMock *cmdMockPkg.Interface
+		dm       *driverMgr
+		cmdMock  *cmdMockPkg.Interface
 		hostMock *hostMockPkg.Interface
-		osMock  *wrappersMockPkg.OSWrapper
-		ctx     context.Context
-		cfg     config.Config
+		osMock   *wrappersMockPkg.OSWrapper
+		ctx      context.Context
+		cfg      config.Config
 	)
 
 	BeforeEach(func() {
@@ -4461,8 +4516,8 @@ var _ = Describe("Unload", func() {
 	setupDiscoverDKMS := func() {
 		mockEntry := mockDirEntry{name: "mlnx-ofa_kernel-5.9-" + moduleVersion, isDir: true}
 		osMock.EXPECT().ReadDir("/usr/src/").Return([]os.DirEntry{mockEntry}, nil)
-		osMock.EXPECT().Stat("/usr/src/mlnx-ofa_kernel-5.9-" + moduleVersion + "/dkms.conf").Return(nil, nil)
-		osMock.EXPECT().ReadFile("/usr/src/mlnx-ofa_kernel-5.9-" + moduleVersion + "/dkms.conf").
+		osMock.EXPECT().Stat("/usr/src/mlnx-ofa_kernel-5.9-"+moduleVersion+"/dkms.conf").Return(nil, nil)
+		osMock.EXPECT().ReadFile("/usr/src/mlnx-ofa_kernel-5.9-"+moduleVersion+"/dkms.conf").
 			Return([]byte("PACKAGE_NAME=\""+moduleName+"\"\nPACKAGE_VERSION=\""+moduleVersion+"\"\n"), nil)
 	}
 


### PR DESCRIPTION
…mounts

mountRootfs/mount_rootfs skipped (re)mounting /usr/src into MLX_DRIVERS_MOUNT whenever a "mellanox" entry was already present in `mount -l`, even if it was a stale bind mount left behind by a previous container instance that terminated without running its cleanup handler (e.g. killed instead of gracefully stopped). The GPU driver container would then see the old, disconnected filesystem snapshot instead of the just-built driver, failing to create the ofa_kernel symlink needed to load nvidia-peermem. Now any existing mount at that path is unmounted first and the bind mount is always recreated fresh.