### PR TITLE
Fix RHEL driver build and module loading

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -419,6 +419,7 @@ function build_driver_from_src() {
     os_str="redhat"
     package_type="rpm"
     append_driver_build_flags="$append_driver_build_flags --disable-kmp"
+    local distro_flags=""
 
     # Conditionally add --without-dkms based on USE_DKMS
     if [[ "${USE_DKMS}" != true ]]; then
@@ -441,12 +442,14 @@ function build_driver_from_src() {
         package_type="rpm"
         append_driver_build_flags="$append_driver_build_flags --disable-kmp"
         append_driver_build_flags="$append_driver_build_flags --kernel-sources /lib/modules/${FULL_KVER}/build"
+    elif [[ -z "${OPENSHIFT_VERSION}" ]]; then
+        distro_flags="--distro rhel${RHEL_VERSION}"
     fi
 
     append_driver_build_flags="$append_driver_build_flags $xpmem_flags"
 
     timestamp_print "Starting driver build"
-    exec_cmd "${NVIDIA_NIC_DRIVER_PATH}/install.pl --without-depcheck --kernel ${FULL_KVER} --kernel-only --build-only --with-mlnx-tools --without-knem${pkg_suffix} --without-iser${pkg_suffix} --without-isert${pkg_suffix} --without-srp${pkg_suffix} --without-kernel-mft${pkg_suffix} --without-mlnx-rdma-rxe${pkg_suffix} ${append_driver_build_flags}"
+    exec_cmd "${NVIDIA_NIC_DRIVER_PATH}/install.pl --without-depcheck --kernel ${FULL_KVER} --kernel-only --build-only --with-mlnx-tools --without-knem${pkg_suffix} --without-iser${pkg_suffix} --without-isert${pkg_suffix} --without-srp${pkg_suffix} --without-kernel-mft${pkg_suffix} --without-mlnx-rdma-rxe${pkg_suffix} ${append_driver_build_flags} ${distro_flags}"
 
     # If build from src triggered driver was not previously built for current kernel
     if [ ${reuse_driver_inventory} ]; then
@@ -598,6 +601,22 @@ function load_host_dependencies() {
             exec_cmd "modprobe -d /host $dep 2>/dev/null || true"
         done
     done
+
+    # openibd later invokes plain modprobe. Preload host inbox dependencies for
+    # OFED entry modules so dependencies such as macsec resolve from /host
+    # instead of the container-labeled /lib/modules bind.
+    if ! lsmod | awk 'NR>1 {print $1}' | grep -qx "mlx5_ib"; then
+        for mod in mlx5_ib mlx5_core ib_core; do
+            deps=$(modinfo -F depends "$mod" 2>/dev/null | tr ',' ' ')
+            for dep in $deps; do
+                dep_path=$(modinfo -b /host -n "$dep" 2>/dev/null || true)
+                if [[ -n "$dep_path" && "$dep_path" != *"/extra/mlnx-ofa_kernel/"* ]]; then
+                    debug_print "Loading host inbox dependency for $mod: $dep ($dep_path)"
+                    exec_cmd "modprobe -d /host $dep 2>/dev/null || true"
+                fi
+            done
+        done
+    fi
 }
 
 function restart_driver() {
@@ -1219,6 +1238,67 @@ function load_driver() {
     set_driver_readiness 1
 }
 
+function link_redhat_host_module_tree() {
+    local ofed_tree="$1"
+    local host_ofed_tree="$2"
+    local ofed_parent_dir="${ofed_tree%/*}"
+    local tmp_ofed_tree="${ofed_tree}.tmp"
+
+    exec_cmd "mkdir -p ${ofed_parent_dir}"
+    exec_cmd "rm -rf ${tmp_ofed_tree}"
+    exec_cmd "ln -s ${host_ofed_tree} ${tmp_ofed_tree}"
+    exec_cmd "rm -rf ${ofed_tree}"
+    exec_cmd "mv -T ${tmp_ofed_tree} ${ofed_tree}"
+}
+
+function ensure_redhat_host_module_tree() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    # This path is only needed for plain RHEL hosts. SLES and OpenShift also
+    # use RPMs, but do not use this RHEL host module/SELinux layout here.
+    if ${IS_OS_UBUNTU} || ${IS_OS_SLES} || [[ ! -z "${OPENSHIFT_VERSION}" ]]; then
+        return
+    fi
+
+    local ofed_tree="/lib/modules/${FULL_KVER}/extra/mlnx-ofa_kernel"
+    local host_modules_dir="/host/lib/modules/${FULL_KVER}"
+    local host_extra_dir="${host_modules_dir}/extra"
+    local host_ofed_tree="${host_extra_dir}/mlnx-ofa_kernel"
+
+    if [[ ! -d "${ofed_tree}" ]]; then
+        if [[ -d "${host_ofed_tree}" ]]; then
+            debug_print "Container OFED module tree missing, restoring host module tree symlink: ${ofed_tree} -> ${host_ofed_tree}"
+            link_redhat_host_module_tree "${ofed_tree}" "${host_ofed_tree}"
+            return
+        fi
+        debug_print "OFED module tree not found, skipping host module tree setup: ${ofed_tree}"
+        return
+    fi
+
+    if [[ ! -d "${host_modules_dir}" ]]; then
+        debug_print "Host kernel module directory not found, skipping host module tree setup: ${host_modules_dir}"
+        return
+    fi
+
+    if [[ "$(readlink -f "${ofed_tree}" 2>/dev/null)" == "${host_ofed_tree}" ]]; then
+        debug_print "OFED module tree already points to host module tree: ${host_ofed_tree}"
+        return
+    fi
+
+    debug_print "Preparing host OFED module tree: ${ofed_tree} -> ${host_ofed_tree}"
+    exec_cmd "mkdir -p ${host_extra_dir}"
+    exec_cmd "rm -rf ${host_ofed_tree}"
+    exec_cmd "cp -a ${ofed_tree} ${host_extra_dir}/"
+
+    if ! chcon -R -t modules_object_t "${host_ofed_tree}"; then
+        debug_print "Failed to label host OFED module tree, continuing: ${host_ofed_tree}"
+    fi
+
+    exec_cmd "depmod -b /host ${FULL_KVER}"
+
+    link_redhat_host_module_tree "${ofed_tree}" "${host_ofed_tree}"
+}
+
 function install_driver() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -1234,6 +1314,7 @@ function install_driver() {
         exec_cmd "apt-get install -y ${driver_inventory_path}/*.deb"
     else
         exec_cmd "rpm -ivh --replacepkgs --nodeps ${driver_inventory_path}/*.rpm"
+        ensure_redhat_host_module_tree
     fi
 
     # Introduce installed kernel modules

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -44,6 +44,10 @@ const (
 	dnfCmd         = "dnf"
 	dnfFlagQuiet   = "-q"
 	dnfFlagYes     = "-y"
+
+	moduleIBCore   = "ib_core"
+	moduleMlx5Core = "mlx5_core"
+	moduleMlx5IB   = "mlx5_ib"
 )
 
 // New creates a new instance of the driver manager
@@ -274,7 +278,7 @@ func (d *driverMgr) Load(ctx context.Context) (bool, error) {
 	log.V(1).Info("Loading driver modules")
 
 	// Define modules to check
-	modulesToCheck := []string{"mlx5_core", "mlx5_ib", "ib_core"}
+	modulesToCheck := []string{moduleMlx5Core, moduleMlx5IB, moduleIBCore}
 
 	// Add NFS RDMA modules if enabled
 	if d.cfg.EnableNfsRdma {
@@ -1136,6 +1140,12 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 	// Add OS-specific flags
 	args = append(args, buildFlags...)
 
+	distroFlags, err := d.getDistroFlagsForOS(ctx, osType)
+	if err != nil {
+		return err
+	}
+	args = append(args, distroFlags...)
+
 	// Exclude xpmem for all OSes; when DKMS is enabled, explicitly exclude xpmem-dkms
 	args = append(args, "--without-xpmem", "--without-xpmem-modules")
 	if d.cfg.UseDKMS {
@@ -1146,7 +1156,7 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 	args = append(args, appendFlags...)
 
 	// Execute the build
-	_, _, err := d.cmd.RunCommand(ctx, args[0], args[1:]...)
+	_, _, err = d.cmd.RunCommand(ctx, args[0], args[1:]...)
 	if err != nil {
 		return fmt.Errorf("failed to build driver from source: %w", err)
 	}
@@ -1188,6 +1198,21 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 	default:
 		return []string{}
 	}
+}
+
+// getDistroFlagsForOS returns explicit install.pl distro flags when runtime
+// auto-detection is known to be less reliable than host OS metadata.
+func (d *driverMgr) getDistroFlagsForOS(ctx context.Context, osType string) ([]string, error) {
+	if osType != constants.OSTypeRedHat {
+		return []string{}, nil
+	}
+
+	versionInfo, err := d.host.GetRedHatVersionInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RedHat version info for driver build: %w", err)
+	}
+
+	return []string{"--distro", "rhel" + versionInfo.FullVersion}, nil
 }
 
 // copyBuildArtifacts copies build artifacts to inventory directory
@@ -1389,7 +1414,7 @@ func (d *driverMgr) installDriver(ctx context.Context, inventoryPath, kernelVers
 	case constants.OSTypeUbuntu:
 		return d.installUbuntuDriver(ctx, inventoryPath, kernelVersion)
 	case constants.OSTypeSLES, constants.OSTypeRedHat, constants.OSTypeOpenShift:
-		return d.installRedHatDriver(ctx, inventoryPath, kernelVersion)
+		return d.installRedHatDriver(ctx, inventoryPath, kernelVersion, osType)
 	default:
 		return fmt.Errorf("unsupported OS type for driver installation: %s", osType)
 	}
@@ -1437,7 +1462,7 @@ func (d *driverMgr) installUbuntuDriver(ctx context.Context, inventoryPath, kern
 }
 
 // installRedHatDriver installs driver packages on RedHat-based systems
-func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kernelVersion string) error {
+func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kernelVersion, osType string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	log.V(1).Info("Installing RedHat driver packages", "path", inventoryPath)
@@ -1448,6 +1473,10 @@ func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kern
 		return fmt.Errorf("failed to install RedHat driver packages: %w", err)
 	}
 
+	if err := d.ensureRedHatHostModuleTree(ctx, kernelVersion, osType); err != nil {
+		return err
+	}
+
 	// Run depmod to introduce installed kernel modules
 	_, _, err = d.cmd.RunCommand(ctx, "depmod", kernelVersion)
 	if err != nil {
@@ -1455,6 +1484,96 @@ func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kern
 	}
 
 	log.V(1).Info("RedHat driver packages installed successfully")
+	return nil
+}
+
+// ensureRedHatHostModuleTree moves OFED kernel modules to the host module tree
+// on RHEL nodes. Kernel modules are host state, and resolving the OFED tree
+// through /host also gives SELinux-enforcing nodes a labelable module path.
+func (d *driverMgr) ensureRedHatHostModuleTree(ctx context.Context, kernelVersion, osType string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	if osType != constants.OSTypeRedHat {
+		return nil
+	}
+
+	ofedTree := filepath.Join("/lib/modules", kernelVersion, "extra", "mlnx-ofa_kernel")
+	hostModulesDir := filepath.Join("/host/lib/modules", kernelVersion)
+	hostExtraDir := filepath.Join(hostModulesDir, "extra")
+	hostOfedTree := filepath.Join(hostExtraDir, "mlnx-ofa_kernel")
+
+	if _, err := d.os.Stat(ofedTree); err != nil {
+		if _, hostErr := d.os.Stat(hostOfedTree); hostErr == nil {
+			log.V(1).Info("Container OFED module tree missing, restoring host module tree symlink", "path", ofedTree, "target", hostOfedTree)
+			return d.linkContainerOFEDTree(ctx, ofedTree, hostOfedTree)
+		}
+		log.V(1).Info("OFED module tree not found, skipping host module tree setup", "path", ofedTree, "error", err)
+		return nil
+	}
+
+	if _, err := d.os.Stat(hostModulesDir); err != nil {
+		log.V(1).Info("Host kernel module directory not found, skipping host module tree setup", "path", hostModulesDir, "error", err)
+		return nil
+	}
+
+	stdout, _, err := d.cmd.RunCommand(ctx, "readlink", "-f", ofedTree)
+	if err == nil && strings.TrimSpace(stdout) == hostOfedTree {
+		log.V(1).Info("OFED module tree already points to host module tree", "path", ofedTree, "target", hostOfedTree)
+		return nil
+	}
+
+	log.V(1).Info("Preparing host OFED module tree for SELinux module loading", "from", ofedTree, "to", hostOfedTree)
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mkdir", "-p", hostExtraDir); err != nil {
+		return fmt.Errorf("failed to create host module extra directory: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", hostOfedTree); err != nil {
+		return fmt.Errorf("failed to remove old host OFED module tree: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/"); err != nil {
+		return fmt.Errorf("failed to copy OFED module tree to host: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree); err != nil {
+		log.V(1).Info("Failed to label host OFED module tree, continuing", "path", hostOfedTree, "error", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "depmod", "-b", "/host", kernelVersion); err != nil {
+		return fmt.Errorf("failed to run host depmod: %w", err)
+	}
+
+	if err := d.linkContainerOFEDTree(ctx, ofedTree, hostOfedTree); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driverMgr) linkContainerOFEDTree(ctx context.Context, ofedTree, hostOfedTree string) error {
+	tmpOfedTree := ofedTree + ".tmp"
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)); err != nil {
+		return fmt.Errorf("failed to create container OFED module parent directory: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", tmpOfedTree); err != nil {
+		return fmt.Errorf("failed to remove stale container OFED module tree symlink: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree); err != nil {
+		return fmt.Errorf("failed to create temporary container OFED module tree symlink: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", ofedTree); err != nil {
+		return fmt.Errorf("failed to remove container OFED module tree: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree); err != nil {
+		return fmt.Errorf("failed to link container OFED module tree to host: %w", err)
+	}
+
 	return nil
 }
 
@@ -1740,9 +1859,18 @@ func (d *driverMgr) loadHostDependencies(ctx context.Context) error {
 		return fmt.Errorf("failed to read /proc/modules: %w", err)
 	}
 
+	loadedModules := make(map[string]struct{})
 	for _, line := range strings.Split(string(content), "\n") {
 		if fields := strings.Fields(line); len(fields) > 0 {
-			d.loadModuleDependencies(ctx, fields[0])
+			module := fields[0]
+			loadedModules[module] = struct{}{}
+			d.loadModuleDependencies(ctx, module)
+		}
+	}
+
+	if _, loaded := loadedModules[moduleMlx5IB]; !loaded {
+		for _, module := range []string{moduleMlx5IB, moduleMlx5Core, moduleIBCore} {
+			d.loadModuleHostInboxDependencies(ctx, module)
 		}
 	}
 	return nil
@@ -1760,6 +1888,37 @@ func (d *driverMgr) loadModuleDependencies(ctx context.Context, modName string) 
 			logr.FromContextOrDiscard(ctx).V(1).Info("Loading dependency", "dependency", dep)
 			_, _, _ = d.cmd.RunCommand(ctx, "modprobe", "-d", "/host", dep)
 		}
+	}
+}
+
+// loadModuleHostInboxDependencies preloads non-OFED dependencies through the
+// host module tree. This prevents plain modprobe calls in openibd from resolving
+// host inbox dependencies through the container-labeled /lib/modules bind.
+func (d *driverMgr) loadModuleHostInboxDependencies(ctx context.Context, modName string) {
+	log := logr.FromContextOrDiscard(ctx)
+
+	output, _, err := d.cmd.RunCommand(ctx, "modinfo", "-F", "depends", modName)
+	if err != nil {
+		return
+	}
+
+	for _, dep := range strings.Split(output, ",") {
+		dep = strings.TrimSpace(dep)
+		if dep == "" {
+			continue
+		}
+
+		hostPath, _, err := d.cmd.RunCommand(ctx, "modinfo", "-b", "/host", "-n", dep)
+		if err != nil {
+			continue
+		}
+		hostPath = strings.TrimSpace(hostPath)
+		if hostPath == "" || strings.Contains(hostPath, "/extra/mlnx-ofa_kernel/") {
+			continue
+		}
+
+		log.V(1).Info("Loading host inbox dependency", "module", modName, "dependency", dep, "path", hostPath)
+		_, _, _ = d.cmd.RunCommand(ctx, "modprobe", "-d", "/host", dep)
 	}
 }
 
@@ -1853,7 +2012,7 @@ func (d *driverMgr) printLoadedDriverVersion(ctx context.Context) error {
 	}
 
 	// Check if mlx5_core is loaded
-	if _, exists := loadedModules["mlx5_core"]; !exists {
+	if _, exists := loadedModules[moduleMlx5Core]; !exists {
 		log.V(1).Info("mlx5_core module not loaded")
 		return nil
 	}

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -639,6 +639,161 @@ var _ = Describe("Driver", func() {
 		})
 	})
 
+	Context("getDistroFlagsForOS", func() {
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+		})
+
+		It("should pass explicit distro for RedHat", func() {
+			versionInfo := &host.RedhatVersionInfo{
+				MajorVersion:     9,
+				FullVersion:      "9.8",
+				OpenShiftVersion: "",
+			}
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil)
+
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(flags).To(Equal([]string{"--distro", "rhel9.8"}))
+		})
+
+		It("should not pass explicit distro for OpenShift", func() {
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeOpenShift)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(flags).To(BeEmpty())
+		})
+
+		It("should return RedHat version errors", func() {
+			expectedError := errors.New("failed to parse version")
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(nil, expectedError)
+
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeRedHat)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get RedHat version info for driver build"))
+			Expect(flags).To(BeNil())
+		})
+	})
+
+	Context("ensureRedHatHostModuleTree", func() {
+		const kernelVersion = "5.14.0-687.5.3.el9_8.x86_64"
+
+		var (
+			ofedTree       string
+			hostModulesDir string
+			hostExtraDir   string
+			hostOfedTree   string
+		)
+
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+			ofedTree = filepath.Join("/lib/modules", kernelVersion, "extra", "mlnx-ofa_kernel")
+			hostModulesDir = filepath.Join("/host/lib/modules", kernelVersion)
+			hostExtraDir = filepath.Join(hostModulesDir, "extra")
+			hostOfedTree = filepath.Join(hostExtraDir, "mlnx-ofa_kernel")
+		})
+
+		It("should skip non-RedHat systems", func() {
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeOpenShift)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the container OFED tree is missing", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat(hostOfedTree).Return(nil, os.ErrNotExist)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should restore the symlink when the container OFED tree is missing but the host tree exists", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			osMock.EXPECT().Stat(ofedTree).Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat(hostOfedTree).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the host module tree is missing", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, os.ErrNotExist)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the OFED tree already resolves to the host tree", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(hostOfedTree+"\n", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should copy, relabel, and link the OFED tree through the host module tree", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should continue when relabeling fails", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			expectedError := errors.New("chcon failed")
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", expectedError)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error when host depmod fails", func() {
+			expectedError := errors.New("depmod failed")
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", expectedError)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to run host depmod"))
+		})
+	})
+
 	Context("getAppendDriverBuildFlags", func() {
 		BeforeEach(func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
@@ -1254,7 +1409,7 @@ var _ = Describe("Driver", func() {
 				FullVersion:      "8.4",
 				OpenShiftVersion: "",
 			}
-			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil).Twice()
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "dnf", "config-manager", "--set-enabled", "rhel-8-for-x86_64-baseos-eus-rpms").Return("", "", nil)
 			osMock.EXPECT().Stat("/lib/modules/5.4.0-42/build").Return(nil, os.ErrNotExist)
@@ -1273,6 +1428,7 @@ var _ = Describe("Driver", func() {
 				"--with-mlnx-tools", "--without-knem", "--without-iser",
 				"--without-isert", "--without-srp", "--without-kernel-mft",
 				"--without-mlnx-rdma-rxe", "--disable-kmp", "--without-dkms",
+				"--distro", "rhel8.4",
 				"--without-xpmem", "--without-xpmem-modules",
 				"--without-mlnx-nfsrdma",
 				"--without-mlnx-nvme").Return("", "", nil)
@@ -1299,6 +1455,8 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42/modules.builtin").Return("", "", nil)
 			// Mock RedHat driver installation
 			cmdMock.EXPECT().RunCommand(ctx, "rpm", "-ivh", "--replacepkgs", "--nodeps", mock.Anything).Return("", "", nil)
+			osMock.EXPECT().Stat("/lib/modules/5.4.0-42/extra/mlnx-ofa_kernel").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/lib/modules/5.4.0-42/extra/mlnx-ofa_kernel").Return(nil, os.ErrNotExist)
 			cmdMock.EXPECT().RunCommand(ctx, "depmod", "5.4.0-42").Return("", "", nil)
 
 			err := dm.Build(ctx)
@@ -2349,6 +2507,31 @@ var _ = Describe("Driver", func() {
 			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("macsec", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "macsec").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
+
+			err := dm.restartDriver(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should preload host inbox dependencies when mlx5_ib is not loaded yet", func() {
+			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx_compat 12288 0 - Live 0xffff\n"), nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx_compat").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("mlx5_core,mlx_compat,ib_core,ib_uverbs,macsec", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx5_core").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "ib_core").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/infiniband/core/ib_core.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "ib_uverbs").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/infiniband/core/ib_uverbs.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "macsec").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/kernel/drivers/net/macsec.ko.xz", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "macsec").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_core").Return("tls,mlx_compat", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "tls").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/kernel/net/tls/tls.ko.xz", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "tls").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "ib_core").Return("mlx_compat", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)


### PR DESCRIPTION
## Summary
- Pass explicit `--distro rhel<version>` to `install.pl` for plain RHEL in both the Go entrypoint and legacy shell source-build path.
- After RHEL RPM installation, copy the installed `mlnx-ofa_kernel` module tree to `/host/lib/modules/<kernel>/extra/`, best-effort label it as `modules_object_t`, run `depmod -b /host <kernel>`, and point the container OFED tree at the host-backed copy.
- Make the container OFED tree relink path crash-recoverable: create a temporary symlink, install it with `mv -T`, and restore the symlink on the next startup if the container path is missing but the host OFED tree exists.
- Before `openibd restart`, preload host inbox dependencies for unloaded OFED entry modules from `/host`, while skipping dependencies that belong to `extra/mlnx-ofa_kernel`. This covers dependencies such as `macsec` and `tls`.
- Keep the Go and shell entrypoint paths aligned.

## Why this is needed
RHEL 9.8 showed `install.pl` failing with `Current operation system is not supported!` even though `/etc/os-release` reported RHEL 9.8. Passing `--distro rhel<version>` from the same host version detection used for `dnf --releasever` makes the build deterministic.

After the build, SELinux-enforcing hosts rejected kernel module loads when modules resolved through container-labeled paths such as `container_file_t`. Moving the OFED tree to the host module mount and labeling it as `modules_object_t` gives module loading a host-backed, labelable path. `depmod -b /host <kernel>` refreshes the host module indexes used by `modprobe -d /host`.

RHEL 10.2 also exposed inbox dependencies of OFED modules, for example `mlx5_ib -> macsec`. Plain `openibd` `modprobe mlx5_ib` can resolve those dependencies through container `/lib/modules`; preloading host inbox dependencies from `/host` avoids that label problem without unloading or blacklisting those modules.

## Why this is safe
- The host OFED tree is populated from modules just built/installed by this driver container.
- The host OFED tree behavior is scoped to plain RHEL; Ubuntu, SLES, and OpenShift skip it.
- Only `/lib/modules/<kernel>/extra/mlnx-ofa_kernel` is replaced with a symlink; the rest of `/lib/modules` is untouched.
- `chcon` is best-effort, so systems without usable SELinux labeling do not fail installation.
- Host dependency preloading only loads dependencies whose `/host` path is outside `extra/mlnx-ofa_kernel`; OFED modules remain managed by `openibd`.
- The dependency preload is non-fatal and matches the existing best-effort dependency handling before restart.

## Validation
- `bash -n entrypoint.sh`
- `git diff --check`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod go test ./internal/driver/... -v`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod GOLANGCI_LINT_CACHE=/private/tmp/doca-driver-build-golangci-cache ./bin/golangci-lint run ./internal/driver/...`
- GitHub checks on `bddd454`: `golangci-lint`, `Unit-tests`, `check go modules`, license, and DCO all pass.

## Runtime notes
- RHEL 9.8 progressed past the original `install.pl` distro detection failure and OFED module SELinux `module_load` denial.
- RHEL 10.2 progressed after host inbox dependency preloading; manual validation showed `modprobe -d /host macsec` succeeds from a `modules_object_t` host path.
