### PR TITLE
Fix OpenShift DTK RHEL driver build flags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -384,6 +384,22 @@ function set_append_driver_build_flags() {
     fi
 }
 
+function get_rhel_version_for_dtk_build() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    local dtk_rhel_version=""
+    dtk_rhel_version=$(sed -n 's/^RHEL_VERSION=//p' /host/etc/os-release 2>/dev/null | head -n1 | tr -d '"')
+
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        dtk_rhel_version=$(echo "${FULL_KVER}" | sed -n 's/.*\.el\([0-9][0-9]*\)_\([0-9][0-9]*\).*/\1.\2/p')
+    fi
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        dtk_rhel_version=$(echo "${FULL_KVER}" | sed -n 's/.*\.el\([0-9][0-9]*\).*/\1/p')
+    fi
+
+    echo "${dtk_rhel_version}"
+}
+
 function dtk_ocp_setup_driver_build() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -391,7 +407,16 @@ function dtk_ocp_setup_driver_build() {
     exec_cmd "mkdir -p ${DTK_OCP_NIC_SHARED_DIR}/"
     exec_cmd "cp -r ${NVIDIA_NIC_DRIVER_PATH} ${DTK_OCP_NIC_SHARED_DIR}/"
 
-    exec_cmd "sed -i '/append_driver_build_flags=/c\append_driver_build_flags=\"${append_driver_build_flags}\"' ${DTK_OCP_BUILD_SCRIPT}"
+    local dtk_rhel_version
+    dtk_rhel_version=$(get_rhel_version_for_dtk_build)
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        timestamp_print "Failed to determine RHEL version for OCP DTK driver build"
+        exit_entryp 1
+    fi
+
+    local dtk_append_driver_build_flags="${append_driver_build_flags} --kernel ${FULL_KVER} --distro rhel${dtk_rhel_version}"
+
+    exec_cmd "sed -i '/append_driver_build_flags=/c\append_driver_build_flags=\"${dtk_append_driver_build_flags}\"' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_COMPILED_DRIVER_VER=/c\DTK_OCP_COMPILED_DRIVER_VER=${NVIDIA_NIC_DRIVER_VER}' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_START_COMPILE_FLAG=/c\DTK_OCP_START_COMPILE_FLAG=${DTK_OCP_START_COMPILE_FLAG}' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_DONE_COMPILE_FLAG=/c\DTK_OCP_DONE_COMPILE_FLAG=${DTK_OCP_DONE_COMPILE_FLAG}' ${DTK_OCP_BUILD_SCRIPT}"

--- a/entrypoint/internal/driver/driver_dtk.go
+++ b/entrypoint/internal/driver/driver_dtk.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/internal/constants"
+	hostutils "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/host"
 )
 
 // buildDriverDTK orchestrates the driver build using the OpenShift Driver Toolkit (DTK)
@@ -51,7 +52,7 @@ func (d *driverMgr) buildDriverDTK(ctx context.Context, kernelVersion, inventory
 	if _, err := d.os.Stat(doneFlagPath); os.IsNotExist(err) {
 		log.Info("DTK build not done, setting up build")
 
-		if err := d.dtkSetupDriverBuild(ctx, dtkSharedDir, startFlagPath, doneFlagPath); err != nil {
+		if err := d.dtkSetupDriverBuild(ctx, dtkSharedDir, startFlagPath, doneFlagPath, kernelVersion); err != nil {
 			return fmt.Errorf("failed to setup DTK build: %w", err)
 		}
 
@@ -80,7 +81,7 @@ func sanitizeKernelVersion(version string) string {
 }
 
 // dtkSetupDriverBuild prepares the shared directory and script for DTK build
-func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFlagPath, doneFlagPath string) error {
+func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFlagPath, doneFlagPath, kernelVersion string) error {
 	log := logr.FromContextOrDiscard(ctx)
 	log.Info("Setting up DTK driver build", "sharedDir", sharedDir)
 
@@ -117,7 +118,10 @@ func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFla
 
 	// Create dtk.env file
 	// Get append flags
-	appendFlags := d.getAppendDriverBuildFlags(constants.OSTypeRedHat)
+	appendFlags, err := d.getDTKAppendDriverBuildFlags(ctx, kernelVersion)
+	if err != nil {
+		return err
+	}
 	appendFlagsStr := strings.Join(appendFlags, " ")
 
 	envContent := fmt.Sprintf(`export DTK_OCP_NIC_SHARED_DIR="%s"
@@ -151,6 +155,43 @@ export USE_DKMS="%v"
 	}
 
 	return nil
+}
+
+func (d *driverMgr) getDTKAppendDriverBuildFlags(ctx context.Context, kernelVersion string) ([]string, error) {
+	appendFlags := d.getAppendDriverBuildFlags(constants.OSTypeRedHat)
+	appendFlags = append(appendFlags, "--kernel", kernelVersion)
+
+	versionInfo, err := d.host.GetRedHatVersionInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RedHat version info for DTK driver build: %w", err)
+	}
+
+	distroVersion := redHatDistroVersion(versionInfo, kernelVersion)
+	if distroVersion == "" {
+		return nil, fmt.Errorf("failed to determine RHEL distro version for DTK driver build")
+	}
+
+	appendFlags = append(appendFlags, "--distro", "rhel"+distroVersion)
+	return appendFlags, nil
+}
+
+func redHatDistroVersion(versionInfo *hostutils.RedhatVersionInfo, kernelVersion string) string {
+	if versionInfo != nil {
+		if versionInfo.RHELVersion != "" {
+			return versionInfo.RHELVersion
+		}
+		if versionInfo.OpenShiftVersion == "" && versionInfo.FullVersion != "" {
+			return versionInfo.FullVersion
+		}
+	}
+
+	if matches := regexp.MustCompile(`\.el([0-9]+)_([0-9]+)`).FindStringSubmatch(kernelVersion); len(matches) == 3 {
+		return matches[1] + "." + matches[2]
+	}
+	if matches := regexp.MustCompile(`\.el([0-9]+)`).FindStringSubmatch(kernelVersion); len(matches) == 2 {
+		return matches[1]
+	}
+	return ""
 }
 
 // dtkWaitForBuild waits for the DTK build to complete

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -4513,13 +4513,15 @@ var _ = Describe("Driver OFED Blacklist", func() {
 
 var _ = Describe("Driver DTK setup", func() {
 	var (
-		cmdMock *cmdMockPkg.Interface
-		ctx     context.Context
-		tempDir string
+		cmdMock  *cmdMockPkg.Interface
+		hostMock *hostMockPkg.Interface
+		ctx      context.Context
+		tempDir  string
 	)
 
 	BeforeEach(func() {
 		cmdMock = cmdMockPkg.NewInterface(GinkgoT())
+		hostMock = hostMockPkg.NewInterface(GinkgoT())
 		ctx = context.Background()
 		tempDir = GinkgoT().TempDir()
 	})
@@ -4544,20 +4546,28 @@ var _ = Describe("Driver DTK setup", func() {
 				UseDKMS:             true,
 				EnableNfsRdma:       true,
 			}
-			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, host: hostMock, os: wrappers.NewOS()}
 
 			sharedDir := filepath.Join(tempDir, "dkms-true")
 			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
 			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+			kernelVersion := "5.14.0-687.13.1.el9_8.x86_64"
 
 			mockCpCalls(dm, sharedDir)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(&host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				RHELVersion:      "9.8",
+				OpenShiftVersion: "4.18",
+			}, nil)
 
-			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath, kernelVersion)
 			Expect(err).NotTo(HaveOccurred())
 
 			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="true"`))
+			Expect(string(content)).To(ContainSubstring(`export APPEND_DRIVER_BUILD_FLAGS="--kernel 5.14.0-687.13.1.el9_8.x86_64 --distro rhel9.8"`))
 			// Sanity-check that other required fields are also present
 			Expect(string(content)).To(ContainSubstring(`export USE_NEW_ENTRYPOINT="true"`))
 			Expect(string(content)).To(ContainSubstring(`export NVIDIA_NIC_DRIVER_VER="26.04-0.5.3.0"`))
@@ -4570,20 +4580,37 @@ var _ = Describe("Driver DTK setup", func() {
 				UseDKMS:             false,
 				EnableNfsRdma:       true,
 			}
-			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, host: hostMock, os: wrappers.NewOS()}
 
 			sharedDir := filepath.Join(tempDir, "dkms-false")
 			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
 			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+			kernelVersion := "5.14.0-687.13.1.el9_8.x86_64"
 
 			mockCpCalls(dm, sharedDir)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(&host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				RHELVersion:      "9.8",
+				OpenShiftVersion: "4.18",
+			}, nil)
 
-			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath, kernelVersion)
 			Expect(err).NotTo(HaveOccurred())
 
 			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="false"`))
+		})
+
+		It("should derive DTK distro version from kernel when RHCOS does not expose RHEL_VERSION", func() {
+			versionInfo := &host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				OpenShiftVersion: "4.18",
+			}
+
+			Expect(redHatDistroVersion(versionInfo, "5.14.0-687.13.1.el9_8.x86_64")).To(Equal("9.8"))
 		})
 	})
 })

--- a/entrypoint/internal/dtk/build_test.go
+++ b/entrypoint/internal/dtk/build_test.go
@@ -32,7 +32,6 @@ import (
 	cmdMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
 )
 
-
 func TestRunBuild(t *testing.T) {
 	log := logr.Discard()
 	tempDir := t.TempDir()
@@ -75,6 +74,7 @@ func TestRunBuild(t *testing.T) {
 	t.Run("should wait for start flag and run build without dkms", func(t *testing.T) {
 		cfgNoDKMS := cfg
 		cfgNoDKMS.UseDKMS = false
+		cfgNoDKMS.AppendDriverBuildFlags = "--kernel 5.14.0-687.13.1.el9_8.x86_64 --distro rhel9.8"
 
 		cmdMock := cmdMockPkg.NewInterface(t)
 		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "perl").Return("", "", nil)
@@ -93,7 +93,8 @@ func TestRunBuild(t *testing.T) {
 		cmdMock.EXPECT().RunCommand(mock.Anything, expectedInstallScript,
 			"--build-only", "--kernel-only", "--without-knem", "--without-iser", "--without-isert",
 			"--without-srp", "--with-mlnx-tools", "--with-ofed-scripts", "--copy-ifnames-udev",
-			"--disable-kmp", "--without-dkms").Return("", "", nil)
+			"--disable-kmp", "--without-dkms", "--kernel", "5.14.0-687.13.1.el9_8.x86_64",
+			"--distro", "rhel9.8").Return("", "", nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		errCh := make(chan error)

--- a/entrypoint/internal/utils/host/host.go
+++ b/entrypoint/internal/utils/host/host.go
@@ -43,6 +43,9 @@ type RedhatVersionInfo struct {
 	MajorVersion int
 	// FullVersion is the complete version string (e.g., "8.4", "9.2")
 	FullVersion string
+	// RHELVersion is the underlying RHEL version when it is distinct from
+	// FullVersion, such as RHCOS hosts where FullVersion is OpenShift 4.x.
+	RHELVersion string
 	// OpenShiftVersion is the OpenShift version if running on RHCOS (e.g., "4.9")
 	// If empty, this is not RHCOS
 	OpenShiftVersion string
@@ -290,6 +293,7 @@ func (h *host) buildRedHatVersionCache() {
 			versionInfo.OpenShiftVersion = constants.DefaultOpenShiftVersion
 		}
 		versionInfo.FullVersion = versionInfo.OpenShiftVersion
+		versionInfo.RHELVersion = rhelVersion
 	} else {
 		// For RHEL and other RedHat-based distros (CentOS, Fedora, etc.)
 		versionInfo.FullVersion = rhelVersion
@@ -304,6 +308,7 @@ func (h *host) buildRedHatVersionCache() {
 		if openshiftVersion != "" {
 			versionInfo.OpenShiftVersion = openshiftVersion
 		}
+		versionInfo.RHELVersion = versionInfo.FullVersion
 	}
 
 	// Extract major version from full version

--- a/entrypoint/internal/utils/host/host_test.go
+++ b/entrypoint/internal/utils/host/host_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/internal/constants"
 	cmd_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
- 	wrappers_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/wrappers/mocks"
+	wrappers_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/wrappers/mocks"
 )
 
 var _ = Describe("Host", func() {
@@ -36,7 +36,7 @@ var _ = Describe("Host", func() {
 		h       Interface
 		ctx     context.Context
 	)
-	
+
 	BeforeEach(func() {
 		cmdMock = cmd_mocks.NewInterface(GinkgoT())
 		osMock = wrappers_mocks.NewOSWrapper(GinkgoT())
@@ -746,6 +746,7 @@ PRETTY_NAME="Red Hat Enterprise Linux 9.2 (Plow)"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(9))
 			Expect(versionInfo.FullVersion).To(Equal("9.2"))
+			Expect(versionInfo.RHELVersion).To(Equal("9.2"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 
@@ -765,6 +766,7 @@ PRETTY_NAME="Red Hat Enterprise Linux 8.4 (Ootpa)"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(8))
 			Expect(versionInfo.FullVersion).To(Equal("8.4"))
+			Expect(versionInfo.RHELVersion).To(Equal("8.4"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 
@@ -859,6 +861,7 @@ OSTREE_VERSION="418.94.202506251005-0"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(4))
 			Expect(versionInfo.FullVersion).To(Equal("4.18"))
+			Expect(versionInfo.RHELVersion).To(Equal("9.4"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal("4.18"))
 		})
 
@@ -876,6 +879,7 @@ RHEL_VERSION="9.2.1"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(9))
 			Expect(versionInfo.FullVersion).To(Equal("9.2.1")) // RHEL_VERSION takes precedence
+			Expect(versionInfo.RHELVersion).To(Equal("9.2.1"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 


### PR DESCRIPTION
## Summary

This is the OpenShift/DTK follow-up to the RHEL source-build fixes that are already in `main`.

On OpenShift, the driver build runs in the dedicated Driver Toolkit sidecar, not in the main driver container. The main container prepares `/mnt/shared-doca-driver-toolkit/<kernel>/dtk.env` and the DTK sidecar executes `entrypoint dtk-build` from that shared directory.

The DTK `install.pl` invocation was still missing the host build identity flags, so it failed immediately with:

```text
Current operation system is not supported!
```

This PR makes the DTK setup pass the target kernel and underlying RHEL distro version into the sidecar via `APPEND_DRIVER_BUILD_FLAGS`, for example:

```text
--kernel 5.14.0-687.13.1.el9_8.x86_64 --distro rhel9.8
```

## What changed

- The Go DTK setup path appends `--kernel <host-kernel>` and `--distro rhel<version>` to the generated `dtk.env`.
- The legacy shell DTK setup path applies the same flags when patching `dtk_nic_driver_build.sh`.
- Host version parsing now keeps a separate `RHELVersion` field, because on RHCOS `FullVersion` intentionally represents the OpenShift version (`4.x`) while `install.pl` needs the underlying RHEL version (`9.x`/`10.x`).
- If RHCOS does not expose `RHEL_VERSION`, the DTK setup falls back to the kernel release suffix, e.g. `.el9_8` -> `9.8`.

## Why this is safe

- This is scoped to the OpenShift DTK build handoff and its shell fallback.
- The existing OpenShift version behavior is preserved; the new field avoids passing OpenShift `4.x` as a RHEL distro version.
- Non-DTK RHEL module-tree and SELinux fixes are already in `main`; this PR does not reintroduce those changes after rebasing.

## Verification

- `bash -n entrypoint.sh`
- `git diff --check upstream/main...HEAD`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod go test ./internal/driver/... -v`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod go test ./internal/dtk/... -v`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod go test ./internal/utils/host/... -v`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache GOMODCACHE=/private/tmp/doca-driver-build-go-mod GOLANGCI_LINT_CACHE=/private/tmp/doca-driver-build-golangci-cache ./bin/golangci-lint run ./internal/driver/... ./internal/dtk/... ./internal/utils/host/...`
