### PR TITLE
Handle mlx5 auxiliary modules during driver reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The following environment variables can be set at container runtime to control d
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OFED_BLACKLIST_MODULES` | `mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm` | Colon-separated list of OFED kernel modules to blacklist on the host. |
+| `MLX5_AUXILIARY_MODULES` | `mlx5_vdpa mlx5_fwctl mlx5_dpll` | Space-separated list of mlx5 auxiliary modules to temporarily blacklist and unload before driver restart, then explicitly reload after the new driver stack is active. Set to an empty string to disable this handling. |
 | `UNLOAD_THIRD_PARTY_RDMA_MODULES` | `false` | When `true`, all known third-party RDMA kernel modules (from rdma-core: qedr, efa, siw, etc.) are blacklisted and unloaded before OFED driver reload. The module list is hardcoded. |
 | `UNLOAD_STORAGE_MODULES` | `false` | When `true`, storage modules (ib_isert, nvme_rdma, etc.) are unloaded during driver restart. |
 | `RESTORE_DRIVER_ON_POD_TERMINATION` | `false` | When `true`, restores the inbox driver on container teardown. |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,6 +49,10 @@
 
 : ${OFED_BLACKLIST_MODULES_FILE:=/host/etc/modprobe.d/blacklist-ofed-modules.conf}
 : ${OFED_BLACKLIST_MODULES:=mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm}
+if [ -z "${MLX5_AUXILIARY_MODULES+x}" ]; then
+    MLX5_AUXILIARY_MODULES="mlx5_vdpa mlx5_fwctl mlx5_dpll"
+fi
+MLX5_AUXILIARY_MODULES_UNLOADED=""
 
 # UNLOAD_THIRD_PARTY_RDMA_MODULES: when true, all known third-party RDMA kernel
 # modules (from rdma-core) are blacklisted and unloaded before OFED driver reload.
@@ -607,11 +611,26 @@ function generate_ofed_modules_blacklist(){
         done
     fi
 
+    if [ -n "${MLX5_AUXILIARY_MODULES}" ]; then
+        echo -e "\n# blacklist mlx5 auxiliary modules to prevent reload races" >> ${OFED_BLACKLIST_MODULES_FILE}
+        for mod in ${MLX5_AUXILIARY_MODULES}; do
+            if ! is_valid_kernel_module_name "${mod}"; then
+                timestamp_print "Skipping invalid mlx5 auxiliary module name: ${mod}"
+                continue
+            fi
+            echo "blacklist $mod" >> ${OFED_BLACKLIST_MODULES_FILE}
+        done
+    fi
+
     debug_print "`cat ${OFED_BLACKLIST_MODULES_FILE}`"
 }
 
 function remove_ofed_modules_blacklist(){
     rm -rf ${OFED_BLACKLIST_MODULES_FILE}; timestamp_print "Remove blacklisted mofed modules file from host"
+}
+
+function is_valid_kernel_module_name() {
+    [[ "$1" =~ ^[A-Za-z0-9_][A-Za-z0-9_-]*$ ]]
 }
 
 function load_host_dependencies() {
@@ -644,6 +663,69 @@ function load_host_dependencies() {
     fi
 }
 
+function unload_mlx5_auxiliary_modules() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    MLX5_AUXILIARY_MODULES_UNLOADED=""
+    for mod in ${MLX5_AUXILIARY_MODULES}; do
+        if ! is_valid_kernel_module_name "${mod}"; then
+            timestamp_print "Skipping invalid mlx5 auxiliary module name: ${mod}"
+            continue
+        fi
+
+        if modprobe -r "${mod}" 2>/dev/null; then
+            MLX5_AUXILIARY_MODULES_UNLOADED="${MLX5_AUXILIARY_MODULES_UNLOADED} ${mod}"
+        else
+            debug_print "Failed to unload mlx5 auxiliary module ${mod}; continuing"
+        fi
+    done
+}
+
+function was_mlx5_auxiliary_module_unloaded() {
+    local module="$1"
+
+    for unloaded_mod in ${MLX5_AUXILIARY_MODULES_UNLOADED}; do
+        if [ "${unloaded_mod}" = "${module}" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+function load_mlx5_auxiliary_modules() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    for mod in ${MLX5_AUXILIARY_MODULES}; do
+        if ! is_valid_kernel_module_name "${mod}"; then
+            timestamp_print "Skipping invalid mlx5 auxiliary module name: ${mod}"
+            continue
+        fi
+
+        if modinfo "${mod}" &>/dev/null; then
+            if ${IS_OS_SLES}; then
+                modprobe --allow-unsupported "${mod}"
+            else
+                modprobe "${mod}"
+            fi
+            modprobe_rc=$?
+            if [ ${modprobe_rc} -ne 0 ]; then
+                if was_mlx5_auxiliary_module_unloaded "${mod}"; then
+                    timestamp_print "Failed to reload previously unloaded mlx5 auxiliary module ${mod}"
+                    exit_entryp ${modprobe_rc}
+                fi
+                timestamp_print "Failed to load mlx5 auxiliary module ${mod}; continuing"
+            fi
+        else
+            if was_mlx5_auxiliary_module_unloaded "${mod}"; then
+                timestamp_print "Failed to find previously unloaded mlx5 auxiliary module ${mod} after driver restart"
+                exit_entryp 1
+            fi
+            debug_print "${mod} module not found; skipping"
+        fi
+    done
+}
+
 function restart_driver() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -668,22 +750,13 @@ function restart_driver() {
     generate_ofed_modules_blacklist
     ${UNLOAD_STORAGE_MODULES} && unload_storage_modules
     ${UNLOAD_THIRD_PARTY_RDMA_MODULES} && unload_third_party_rdma_modules
+    unload_mlx5_auxiliary_modules
 
     exec_cmd "/etc/init.d/openibd restart"
 
-    # Explicitly load the mlx5_vdpa module from the container to prevent loading an incompatible version from the host.
-    # In Ubuntu 24.04, the inbox (built-in) mlx5_vdpa module is automatically loaded due to the "alias: auxiliary:mlx5_core.vnet" entry.
-    # Load mlx5_vdpa only if present
-
-    if modinfo mlx5_vdpa &>/dev/null; then
-        if ${IS_OS_SLES}; then
-            exec_cmd "modprobe --allow-unsupported mlx5_vdpa"
-        else
-            exec_cmd "modprobe mlx5_vdpa"
-        fi
-    else
-        debug_print "mlx5_vdpa module not found; skipping"
-    fi
+    # Explicitly load mlx5 auxiliary modules from the container to avoid
+    # alias-driven reload races while the OFED stack is being replaced.
+    load_mlx5_auxiliary_modules
 
     remove_ofed_modules_blacklist
 

--- a/entrypoint/internal/config/config.go
+++ b/entrypoint/internal/config/config.go
@@ -18,6 +18,8 @@
 package config
 
 import (
+	"os"
+
 	"github.com/caarlos0/env/v11"
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/pkg/mofedmodules"
@@ -53,6 +55,7 @@ type Config struct {
 
 	OfedBlacklistModulesFile string   `env:"OFED_BLACKLIST_MODULES_FILE" envDefault:"/host/etc/modprobe.d/blacklist-ofed-modules.conf"`
 	OfedBlacklistModules     []string `env:"OFED_BLACKLIST_MODULES"      envDefault:"mlx5_core:mlx5_ib:ib_umad:ib_uverbs:ib_ipoib:rdma_cm:rdma_ucm:ib_core:ib_cm" envSeparator:":"`
+	Mlx5AuxiliaryModules     []string `env:"MLX5_AUXILIARY_MODULES"      envSeparator:" "`
 	// StorageModules defaults to mofedmodules.DefaultStorageModules when unset; see GetConfig.
 	StorageModules []string `env:"STORAGE_MODULES" envSeparator:" "`
 	// ThirdPartyRDMAModules defaults to mofedmodules.DefaultThirdPartyRDMAModules when unset; see GetConfig.
@@ -76,9 +79,11 @@ type Config struct {
 	BindDelaySec        int    `env:"BIND_DELAY_SEC"          envDefault:"4"`
 }
 
+var DefaultMlx5AuxiliaryModules = []string{"mlx5_vdpa", "mlx5_fwctl", "mlx5_dpll"}
+
 // GetConfig parses environment variables and returns a Config struct.
-// When STORAGE_MODULES or THIRD_PARTY_RDMA_MODULES is unset, the corresponding
-// slice is populated from the canonical defaults in the mofedmodules package.
+// When module-list environment variables are unset, the corresponding slices
+// are populated from the canonical defaults.
 func GetConfig() (Config, error) {
 	var cfg Config
 	if err := env.Parse(&cfg); err != nil {
@@ -89,6 +94,9 @@ func GetConfig() (Config, error) {
 	}
 	if len(cfg.ThirdPartyRDMAModules) == 0 {
 		cfg.ThirdPartyRDMAModules = append(cfg.ThirdPartyRDMAModules, mofedmodules.DefaultThirdPartyRDMAModules...)
+	}
+	if _, configured := os.LookupEnv("MLX5_AUXILIARY_MODULES"); !configured && len(cfg.Mlx5AuxiliaryModules) == 0 {
+		cfg.Mlx5AuxiliaryModules = append(cfg.Mlx5AuxiliaryModules, DefaultMlx5AuxiliaryModules...)
 	}
 	return cfg, nil
 }

--- a/entrypoint/internal/config/config_test.go
+++ b/entrypoint/internal/config/config_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("UNLOAD_THIRD_PARTY_RDMA_MODULES")
 		os.Unsetenv("THIRD_PARTY_RDMA_MODULES")
 		os.Unsetenv("STORAGE_MODULES")
+		os.Unsetenv("MLX5_AUXILIARY_MODULES")
 	})
 
 	Context("UnloadThirdPartyRdmaModules", func() {
@@ -97,6 +98,32 @@ var _ = Describe("Config", func() {
 			cfg, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.ThirdPartyRDMAModules).To(Equal([]string{"foo_re", "bar_rdma", "baz_ib"}))
+		})
+	})
+
+	Context("Mlx5AuxiliaryModules", func() {
+		It("should parse the default list when MLX5_AUXILIARY_MODULES is not set", func() {
+			os.Unsetenv("MLX5_AUXILIARY_MODULES")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Mlx5AuxiliaryModules).To(Equal([]string{"mlx5_vdpa", "mlx5_fwctl", "mlx5_dpll"}))
+		})
+
+		It("should parse a space-separated override correctly", func() {
+			os.Setenv("MLX5_AUXILIARY_MODULES", "mlx5_fwctl mlx5_dpll")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Mlx5AuxiliaryModules).To(Equal([]string{"mlx5_fwctl", "mlx5_dpll"}))
+		})
+
+		It("should allow an explicit empty override", func() {
+			os.Setenv("MLX5_AUXILIARY_MODULES", "")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Mlx5AuxiliaryModules).To(BeEmpty())
 		})
 	})
 })

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -50,6 +50,8 @@ const (
 	moduleMlx5IB   = "mlx5_ib"
 )
 
+var kernelModuleNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]*$`)
+
 // New creates a new instance of the driver manager
 func New(containerMode string, cfg config.Config,
 	c cmd.Interface, h host.Interface, osWrapper wrappers.OSWrapper,
@@ -864,6 +866,18 @@ func (d *driverMgr) generateOfedModulesBlacklist(ctx context.Context) error {
 		for _, module := range d.cfg.ThirdPartyRDMAModules {
 			fmt.Fprintf(&content, "blacklist %s\n", module)
 			log.V(2).Info("Added third-party RDMA module to blacklist", "module", module)
+		}
+	}
+
+	if len(d.cfg.Mlx5AuxiliaryModules) > 0 {
+		content.WriteString("\n# blacklist mlx5 auxiliary modules to prevent reload races\n")
+		for _, module := range d.cfg.Mlx5AuxiliaryModules {
+			module = strings.TrimSpace(module)
+			if module == "" {
+				continue
+			}
+			fmt.Fprintf(&content, "blacklist %s\n", module)
+			log.V(2).Info("Added mlx5 auxiliary module to blacklist", "module", module)
 		}
 	}
 
@@ -1952,35 +1966,92 @@ func (d *driverMgr) restartDriver(ctx context.Context) error {
 		}
 	}
 
+	unloadedMlx5AuxiliaryModules := d.unloadMlx5AuxiliaryModules(ctx)
+
 	// Restart openibd service
 	_, _, err := d.cmd.RunCommand(ctx, "/etc/init.d/openibd", "restart")
 	if err != nil {
 		return fmt.Errorf("failed to restart openibd service: %w", err)
 	}
 
-	// Load mlx5_vdpa if available
-	_, _, err = d.cmd.RunCommand(ctx, "modinfo", "mlx5_vdpa")
-	if err == nil {
-		// Module exists, try to load it
-		// On SLES, we need --allow-unsupported
-		osType, err := d.host.GetOSType(ctx)
-		if err != nil {
-			log.V(1).Info("Failed to get OS type, proceeding without --allow-unsupported flag", "error", err)
-		}
-		if osType == constants.OSTypeSLES {
-			_, _, err = d.cmd.RunCommand(ctx, "modprobe", "--allow-unsupported", "mlx5_vdpa")
-		} else {
-			_, _, err = d.cmd.RunCommand(ctx, "modprobe", "mlx5_vdpa")
-		}
-		if err != nil {
-			log.V(1).Info("Failed to load mlx5_vdpa module", "error", err)
-			// Non-fatal, continue
-		}
-	} else {
-		log.V(1).Info("mlx5_vdpa module not found, skipping")
+	if err := d.loadMlx5AuxiliaryModules(ctx, unloadedMlx5AuxiliaryModules); err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (d *driverMgr) unloadMlx5AuxiliaryModules(ctx context.Context) map[string]struct{} {
+	log := logr.FromContextOrDiscard(ctx)
+	unloadedModules := map[string]struct{}{}
+
+	for _, module := range d.cfg.Mlx5AuxiliaryModules {
+		module, ok := sanitizeKernelModuleName(module)
+		if !ok {
+			log.V(1).Info("Skipping invalid mlx5 auxiliary module name", "module", module)
+			continue
+		}
+
+		if _, _, err := d.cmd.RunCommand(ctx, "modprobe", "-r", module); err != nil {
+			log.V(1).Info("Failed to unload mlx5 auxiliary module", "module", module, "error", err)
+			continue
+		}
+		unloadedModules[module] = struct{}{}
+	}
+
+	return unloadedModules
+}
+
+func (d *driverMgr) loadMlx5AuxiliaryModules(ctx context.Context, unloadedModules map[string]struct{}) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	if len(d.cfg.Mlx5AuxiliaryModules) == 0 {
+		return nil
+	}
+
+	osType, osTypeErr := d.host.GetOSType(ctx)
+	if osTypeErr != nil {
+		log.V(1).Info("Failed to get OS type, proceeding without --allow-unsupported flag", "error", osTypeErr)
+	}
+
+	for _, module := range d.cfg.Mlx5AuxiliaryModules {
+		module, ok := sanitizeKernelModuleName(module)
+		if !ok {
+			log.V(1).Info("Skipping invalid mlx5 auxiliary module name", "module", module)
+			continue
+		}
+
+		if _, _, err := d.cmd.RunCommand(ctx, "modinfo", module); err != nil {
+			if _, wasUnloaded := unloadedModules[module]; wasUnloaded {
+				return fmt.Errorf("failed to find previously unloaded mlx5 auxiliary module %s after driver restart: %w", module, err)
+			}
+			log.V(1).Info("mlx5 auxiliary module not found, skipping", "module", module)
+			continue
+		}
+
+		var err error
+		if osType == constants.OSTypeSLES {
+			_, _, err = d.cmd.RunCommand(ctx, "modprobe", "--allow-unsupported", module)
+		} else {
+			_, _, err = d.cmd.RunCommand(ctx, "modprobe", module)
+		}
+		if err != nil {
+			log.V(1).Info("Failed to load mlx5 auxiliary module", "module", module, "error", err)
+			if _, wasUnloaded := unloadedModules[module]; wasUnloaded {
+				return fmt.Errorf("failed to reload previously unloaded mlx5 auxiliary module %s: %w", module, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func sanitizeKernelModuleName(module string) (string, bool) {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return "", false
+	}
+	return module, kernelModuleNamePattern.MatchString(module)
 }
 
 // loadNfsRdma loads NFS RDMA modules if enabled

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -2158,7 +2158,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			// Mock printLoadedDriverVersion
 			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
@@ -2218,7 +2217,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			// Mock loadNfsRdma
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "rpcrdma").Return("", "", nil)
@@ -2332,7 +2330,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			// Mock loadNfsRdma failure (should not cause Load to fail)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "rpcrdma").Return("", "", errors.New("rpcrdma load failed"))
@@ -2496,7 +2493,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2510,7 +2506,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2535,7 +2530,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2548,18 +2542,21 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("aarch64", "", nil)
 			// pci-hyperv-intf should not be called for aarch64
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should load mlx5_vdpa when available", func() {
+			cfg.Mlx5AuxiliaryModules = []string{"mlx5_vdpa"}
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
 			// Mock loadHostDependencies
 			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_vdpa").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", nil) // Module exists
 			// Mock GetOSType for non-SLES case
@@ -2571,16 +2568,75 @@ var _ = Describe("Driver", func() {
 		})
 
 		It("should load mlx5_vdpa with --allow-unsupported on SLES", func() {
+			cfg.Mlx5AuxiliaryModules = []string{"mlx5_vdpa"}
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
 			// Mock loadHostDependencies
 			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_vdpa").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", nil) // Module exists
 			// Mock GetOSType for SLES case
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeSLES, nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "--allow-unsupported", "mlx5_vdpa").Return("", "", nil)
+
+			err := dm.restartDriver(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail when a previously unloaded mlx5 auxiliary module cannot be reloaded", func() {
+			cfg.Mlx5AuxiliaryModules = []string{"mlx5_fwctl"}
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_fwctl").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeRedHat, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_fwctl").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "mlx5_fwctl").Return("", "", errors.New("reload failed"))
+
+			err := dm.restartDriver(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to reload previously unloaded mlx5 auxiliary module mlx5_fwctl"))
+		})
+
+		It("should fail when a previously unloaded mlx5 auxiliary module is missing after restart", func() {
+			cfg.Mlx5AuxiliaryModules = []string{"mlx5_fwctl"}
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_fwctl").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeRedHat, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_fwctl").Return("", "", errors.New("not found"))
+
+			err := dm.restartDriver(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to find previously unloaded mlx5 auxiliary module mlx5_fwctl after driver restart"))
+		})
+
+		It("should continue when a mlx5 auxiliary module that was not unloaded cannot be loaded", func() {
+			cfg.Mlx5AuxiliaryModules = []string{"mlx5_fwctl"}
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_fwctl").Return("", "", errors.New("not loaded"))
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeRedHat, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_fwctl").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "mlx5_fwctl").Return("", "", errors.New("load failed"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2604,7 +2660,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("1", "", nil)
 
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -2633,7 +2688,6 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", errors.New("pci-hyperv-intf load failed"))
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -4230,6 +4284,34 @@ var _ = Describe("Driver OFED Blacklist", func() {
 				}
 			}
 			Expect(blacklistLines).To(Equal(2))
+		})
+
+		It("should include mlx5 auxiliary modules in blacklist when configured", func() {
+			blacklistFile := filepath.Join(tempDir, "mlx5-auxiliary-blacklist.conf")
+			cfg := config.Config{
+				OfedBlacklistModulesFile: blacklistFile,
+				OfedBlacklistModules:     []string{"mlx5_core"},
+				Mlx5AuxiliaryModules:     []string{"mlx5_vdpa", "mlx5_fwctl", "mlx5_dpll"},
+			}
+
+			dm = &driverMgr{
+				cfg:  cfg,
+				cmd:  cmdMock,
+				host: hostMock,
+				os:   wrappers.NewOS(),
+			}
+
+			err := dm.generateOfedModulesBlacklist(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			content, err := os.ReadFile(blacklistFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			contentStr := string(content)
+			Expect(contentStr).To(ContainSubstring("# blacklist mlx5 auxiliary modules to prevent reload races"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_vdpa"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_fwctl"))
+			Expect(contentStr).To(ContainSubstring("blacklist mlx5_dpll"))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- add `MLX5_AUXILIARY_MODULES` for mlx5 auxiliary modules that can autoload from `mlx5_core` auxiliary devices
- temporarily blacklist and best-effort unload those modules before `openibd restart`
- explicitly reload available mlx5 auxiliary modules after the OFED stack is active
- document the runtime env var and add config/driver tests

## Validation
- `bash -n entrypoint.sh`
- `go test ./internal/config/... ./internal/driver/... -v`
- `./bin/golangci-lint run ./internal/config/... ./internal/driver/...`
- `make build TARGETOS=linux TARGETARCH=amd64`

Note: `go build ./...` in `entrypoint/` still hits the existing `sriovnet/netlink` dependency issue unrelated to this change.
