### PR TITLE
Backport RHEL driver build fixes to 26.4

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -398,6 +398,7 @@ function build_driver_from_src() {
     os_str="redhat"
     package_type="rpm"
     append_driver_build_flags="$append_driver_build_flags --disable-kmp"
+    local distro_flags=""
 
     # Conditionally add --without-dkms based on USE_DKMS
     if [[ "${USE_DKMS}" != true ]]; then
@@ -420,12 +421,14 @@ function build_driver_from_src() {
         package_type="rpm"
         append_driver_build_flags="$append_driver_build_flags --disable-kmp"
         append_driver_build_flags="$append_driver_build_flags --kernel-sources /lib/modules/${FULL_KVER}/build"
+    elif [[ -z "${OPENSHIFT_VERSION}" ]]; then
+        distro_flags="--distro rhel${RHEL_VERSION}"
     fi
 
     append_driver_build_flags="$append_driver_build_flags $xpmem_flags"
 
     timestamp_print "Starting driver build"
-    exec_cmd "${NVIDIA_NIC_DRIVER_PATH}/install.pl --without-depcheck --kernel ${FULL_KVER} --kernel-only --build-only --with-mlnx-tools --without-knem${pkg_suffix} --without-iser${pkg_suffix} --without-isert${pkg_suffix} --without-srp${pkg_suffix} --without-kernel-mft${pkg_suffix} --without-mlnx-rdma-rxe${pkg_suffix} ${append_driver_build_flags}"
+    exec_cmd "${NVIDIA_NIC_DRIVER_PATH}/install.pl --without-depcheck --kernel ${FULL_KVER} --kernel-only --build-only --with-mlnx-tools --without-knem${pkg_suffix} --without-iser${pkg_suffix} --without-isert${pkg_suffix} --without-srp${pkg_suffix} --without-kernel-mft${pkg_suffix} --without-mlnx-rdma-rxe${pkg_suffix} ${append_driver_build_flags} ${distro_flags}"
 
     # If build from src triggered driver was not previously built for current kernel
     if [ ${reuse_driver_inventory} ]; then
@@ -577,6 +580,22 @@ function load_host_dependencies() {
             exec_cmd "modprobe -d /host $dep 2>/dev/null || true"
         done
     done
+
+    # openibd later invokes plain modprobe. Preload host inbox dependencies for
+    # OFED entry modules so dependencies such as macsec resolve from /host
+    # instead of the container-labeled /lib/modules bind.
+    if ! lsmod | awk 'NR>1 {print $1}' | grep -qx "mlx5_ib"; then
+        for mod in mlx5_ib mlx5_core ib_core; do
+            deps=$(modinfo -F depends "$mod" 2>/dev/null | tr ',' ' ')
+            for dep in $deps; do
+                dep_path=$(modinfo -b /host -n "$dep" 2>/dev/null || true)
+                if [[ -n "$dep_path" && "$dep_path" != *"/extra/mlnx-ofa_kernel/"* ]]; then
+                    debug_print "Loading host inbox dependency for $mod: $dep ($dep_path)"
+                    exec_cmd "modprobe -d /host $dep 2>/dev/null || true"
+                fi
+            done
+        done
+    fi
 }
 
 function restart_driver() {
@@ -1198,6 +1217,67 @@ function load_driver() {
     set_driver_readiness 1
 }
 
+function link_redhat_host_module_tree() {
+    local ofed_tree="$1"
+    local host_ofed_tree="$2"
+    local ofed_parent_dir="${ofed_tree%/*}"
+    local tmp_ofed_tree="${ofed_tree}.tmp"
+
+    exec_cmd "mkdir -p ${ofed_parent_dir}"
+    exec_cmd "rm -rf ${tmp_ofed_tree}"
+    exec_cmd "ln -s ${host_ofed_tree} ${tmp_ofed_tree}"
+    exec_cmd "rm -rf ${ofed_tree}"
+    exec_cmd "mv -T ${tmp_ofed_tree} ${ofed_tree}"
+}
+
+function ensure_redhat_host_module_tree() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    # This path is only needed for plain RHEL hosts. SLES and OpenShift also
+    # use RPMs, but do not use this RHEL host module/SELinux layout here.
+    if ${IS_OS_UBUNTU} || ${IS_OS_SLES} || [[ ! -z "${OPENSHIFT_VERSION}" ]]; then
+        return
+    fi
+
+    local ofed_tree="/lib/modules/${FULL_KVER}/extra/mlnx-ofa_kernel"
+    local host_modules_dir="/host/lib/modules/${FULL_KVER}"
+    local host_extra_dir="${host_modules_dir}/extra"
+    local host_ofed_tree="${host_extra_dir}/mlnx-ofa_kernel"
+
+    if [[ ! -d "${ofed_tree}" ]]; then
+        if [[ -d "${host_ofed_tree}" ]]; then
+            debug_print "Container OFED module tree missing, restoring host module tree symlink: ${ofed_tree} -> ${host_ofed_tree}"
+            link_redhat_host_module_tree "${ofed_tree}" "${host_ofed_tree}"
+            return
+        fi
+        debug_print "OFED module tree not found, skipping host module tree setup: ${ofed_tree}"
+        return
+    fi
+
+    if [[ ! -d "${host_modules_dir}" ]]; then
+        debug_print "Host kernel module directory not found, skipping host module tree setup: ${host_modules_dir}"
+        return
+    fi
+
+    if [[ "$(readlink -f "${ofed_tree}" 2>/dev/null)" == "${host_ofed_tree}" ]]; then
+        debug_print "OFED module tree already points to host module tree: ${host_ofed_tree}"
+        return
+    fi
+
+    debug_print "Preparing host OFED module tree: ${ofed_tree} -> ${host_ofed_tree}"
+    exec_cmd "mkdir -p ${host_extra_dir}"
+    exec_cmd "rm -rf ${host_ofed_tree}"
+    exec_cmd "cp -a ${ofed_tree} ${host_extra_dir}/"
+
+    if ! chcon -R -t modules_object_t "${host_ofed_tree}"; then
+        debug_print "Failed to label host OFED module tree, continuing: ${host_ofed_tree}"
+    fi
+
+    exec_cmd "depmod -b /host ${FULL_KVER}"
+
+    link_redhat_host_module_tree "${ofed_tree}" "${host_ofed_tree}"
+}
+
 function install_driver() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -1213,6 +1293,7 @@ function install_driver() {
         exec_cmd "apt-get install -y ${driver_inventory_path}/*.deb"
     else
         exec_cmd "rpm -ivh --replacepkgs --nodeps ${driver_inventory_path}/*.rpm"
+        ensure_redhat_host_module_tree
     fi
 
     # Introduce installed kernel modules

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -363,6 +363,22 @@ function set_append_driver_build_flags() {
     fi
 }
 
+function get_rhel_version_for_dtk_build() {
+    debug_print "Function: ${FUNCNAME[0]}"
+
+    local dtk_rhel_version=""
+    dtk_rhel_version=$(sed -n 's/^RHEL_VERSION=//p' /host/etc/os-release 2>/dev/null | head -n1 | tr -d '"')
+
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        dtk_rhel_version=$(echo "${FULL_KVER}" | sed -n 's/.*\.el\([0-9][0-9]*\)_\([0-9][0-9]*\).*/\1.\2/p')
+    fi
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        dtk_rhel_version=$(echo "${FULL_KVER}" | sed -n 's/.*\.el\([0-9][0-9]*\).*/\1/p')
+    fi
+
+    echo "${dtk_rhel_version}"
+}
+
 function dtk_ocp_setup_driver_build() {
     debug_print "Function: ${FUNCNAME[0]}"
 
@@ -370,7 +386,16 @@ function dtk_ocp_setup_driver_build() {
     exec_cmd "mkdir -p ${DTK_OCP_NIC_SHARED_DIR}/"
     exec_cmd "cp -r ${NVIDIA_NIC_DRIVER_PATH} ${DTK_OCP_NIC_SHARED_DIR}/"
 
-    exec_cmd "sed -i '/append_driver_build_flags=/c\append_driver_build_flags=\"${append_driver_build_flags}\"' ${DTK_OCP_BUILD_SCRIPT}"
+    local dtk_rhel_version
+    dtk_rhel_version=$(get_rhel_version_for_dtk_build)
+    if [[ -z "${dtk_rhel_version}" ]]; then
+        timestamp_print "Failed to determine RHEL version for OCP DTK driver build"
+        exit_entryp 1
+    fi
+
+    local dtk_append_driver_build_flags="${append_driver_build_flags} --kernel ${FULL_KVER} --distro rhel${dtk_rhel_version}"
+
+    exec_cmd "sed -i '/append_driver_build_flags=/c\append_driver_build_flags=\"${dtk_append_driver_build_flags}\"' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_COMPILED_DRIVER_VER=/c\DTK_OCP_COMPILED_DRIVER_VER=${NVIDIA_NIC_DRIVER_VER}' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_START_COMPILE_FLAG=/c\DTK_OCP_START_COMPILE_FLAG=${DTK_OCP_START_COMPILE_FLAG}' ${DTK_OCP_BUILD_SCRIPT}"
     exec_cmd "sed -i '/DTK_OCP_DONE_COMPILE_FLAG=/c\DTK_OCP_DONE_COMPILE_FLAG=${DTK_OCP_DONE_COMPILE_FLAG}' ${DTK_OCP_BUILD_SCRIPT}"

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -39,6 +39,15 @@ const (
 	kernelTypeStandard = "standard"
 	kernelTypeRT       = "rt"
 	kernelType64k      = "64k"
+
+	flagDisableKMP = "--disable-kmp"
+	dnfCmd         = "dnf"
+	dnfFlagQuiet   = "-q"
+	dnfFlagYes     = "-y"
+
+	moduleIBCore   = "ib_core"
+	moduleMlx5Core = "mlx5_core"
+	moduleMlx5IB   = "mlx5_ib"
 )
 
 // New creates a new instance of the driver manager
@@ -261,7 +270,7 @@ func (d *driverMgr) Load(ctx context.Context) (bool, error) {
 	log.V(1).Info("Loading driver modules")
 
 	// Define modules to check
-	modulesToCheck := []string{"mlx5_core", "mlx5_ib", "ib_core"}
+	modulesToCheck := []string{moduleMlx5Core, moduleMlx5IB, moduleIBCore}
 
 	// Add NFS RDMA modules if enabled
 	if d.cfg.EnableNfsRdma {
@@ -705,12 +714,12 @@ func (d *driverMgr) installGCCRedHat(ctx context.Context, majorVersion int) (str
 	log.V(1).Info("Checking for gcc-toolset availability", "package", toolsetPackage)
 
 	// Check if gcc-toolset is available
-	_, _, err := d.cmd.RunCommand(ctx, "dnf", "list", "available", toolsetPackage)
+	_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "list", "available", toolsetPackage)
 	if err == nil {
 		// gcc-toolset version is available
 		kernelGCCVer := fmt.Sprintf("gcc-toolset-%d-gcc", majorVersion)
 		log.V(1).Info("Installing gcc-toolset for RedHat", "package", toolsetPackage)
-		_, _, err = d.cmd.RunCommand(ctx, "dnf", "-q", "-y", "install", toolsetPackage)
+		_, _, err = d.cmd.RunCommand(ctx, dnfCmd, dnfFlagQuiet, dnfFlagYes, "install", toolsetPackage)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to install %s: %w", toolsetPackage, err)
 		}
@@ -721,7 +730,7 @@ func (d *driverMgr) installGCCRedHat(ctx context.Context, majorVersion int) (str
 	// Fall back to default gcc package
 	log.V(1).Info("gcc-toolset not available, using default gcc package")
 	kernelGCCVer := "gcc"
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "-q", "-y", "install", "gcc")
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, dnfFlagQuiet, dnfFlagYes, "install", "gcc")
 	if err != nil {
 		return "", "", fmt.Errorf("failed to install gcc: %w", err)
 	}
@@ -1097,6 +1106,12 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 	// Add OS-specific flags
 	args = append(args, buildFlags...)
 
+	distroFlags, err := d.getDistroFlagsForOS(ctx, osType)
+	if err != nil {
+		return err
+	}
+	args = append(args, distroFlags...)
+
 	// Exclude xpmem for all OSes; when DKMS is enabled, explicitly exclude xpmem-dkms
 	args = append(args, "--without-xpmem", "--without-xpmem-modules")
 	if d.cfg.UseDKMS {
@@ -1107,7 +1122,7 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 	args = append(args, appendFlags...)
 
 	// Execute the build
-	_, _, err := d.cmd.RunCommand(ctx, args[0], args[1:]...)
+	_, _, err = d.cmd.RunCommand(ctx, args[0], args[1:]...)
 	if err != nil {
 		return fmt.Errorf("failed to build driver from source: %w", err)
 	}
@@ -1120,7 +1135,7 @@ func (d *driverMgr) buildDriverFromSource(ctx context.Context, driverPath, kerne
 func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 	switch osType {
 	case constants.OSTypeUbuntu:
-		flags := []string{"--disable-kmp"}
+		flags := []string{flagDisableKMP}
 		// Conditionally add --without-dkms based on config
 		// If UseDKMS is true, we want install.pl to create DKMS packages
 		if !d.cfg.UseDKMS {
@@ -1129,7 +1144,7 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 		return flags
 	case constants.OSTypeSLES:
 		flags := []string{
-			"--disable-kmp",
+			flagDisableKMP,
 		}
 		// Conditionally add --without-dkms based on config (must come before --kernel-sources)
 		if !d.cfg.UseDKMS {
@@ -1140,7 +1155,7 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 		)
 		return flags
 	case constants.OSTypeRedHat:
-		flags := []string{"--disable-kmp"}
+		flags := []string{flagDisableKMP}
 		// Conditionally add --without-dkms based on config
 		if !d.cfg.UseDKMS {
 			flags = append(flags, "--without-dkms")
@@ -1149,6 +1164,21 @@ func (d *driverMgr) getBuildFlagsForOS(osType, kernelVersion string) []string {
 	default:
 		return []string{}
 	}
+}
+
+// getDistroFlagsForOS returns explicit install.pl distro flags when runtime
+// auto-detection is known to be less reliable than host OS metadata.
+func (d *driverMgr) getDistroFlagsForOS(ctx context.Context, osType string) ([]string, error) {
+	if osType != constants.OSTypeRedHat {
+		return []string{}, nil
+	}
+
+	versionInfo, err := d.host.GetRedHatVersionInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RedHat version info for driver build: %w", err)
+	}
+
+	return []string{"--distro", "rhel" + versionInfo.FullVersion}, nil
 }
 
 // copyBuildArtifacts copies build artifacts to inventory directory
@@ -1350,7 +1380,7 @@ func (d *driverMgr) installDriver(ctx context.Context, inventoryPath, kernelVers
 	case constants.OSTypeUbuntu:
 		return d.installUbuntuDriver(ctx, inventoryPath, kernelVersion)
 	case constants.OSTypeSLES, constants.OSTypeRedHat, constants.OSTypeOpenShift:
-		return d.installRedHatDriver(ctx, inventoryPath, kernelVersion)
+		return d.installRedHatDriver(ctx, inventoryPath, kernelVersion, osType)
 	default:
 		return fmt.Errorf("unsupported OS type for driver installation: %s", osType)
 	}
@@ -1398,7 +1428,7 @@ func (d *driverMgr) installUbuntuDriver(ctx context.Context, inventoryPath, kern
 }
 
 // installRedHatDriver installs driver packages on RedHat-based systems
-func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kernelVersion string) error {
+func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kernelVersion, osType string) error {
 	log := logr.FromContextOrDiscard(ctx)
 
 	log.V(1).Info("Installing RedHat driver packages", "path", inventoryPath)
@@ -1409,6 +1439,10 @@ func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kern
 		return fmt.Errorf("failed to install RedHat driver packages: %w", err)
 	}
 
+	if err := d.ensureRedHatHostModuleTree(ctx, kernelVersion, osType); err != nil {
+		return err
+	}
+
 	// Run depmod to introduce installed kernel modules
 	_, _, err = d.cmd.RunCommand(ctx, "depmod", kernelVersion)
 	if err != nil {
@@ -1416,6 +1450,96 @@ func (d *driverMgr) installRedHatDriver(ctx context.Context, inventoryPath, kern
 	}
 
 	log.V(1).Info("RedHat driver packages installed successfully")
+	return nil
+}
+
+// ensureRedHatHostModuleTree moves OFED kernel modules to the host module tree
+// on RHEL nodes. Kernel modules are host state, and resolving the OFED tree
+// through /host also gives SELinux-enforcing nodes a labelable module path.
+func (d *driverMgr) ensureRedHatHostModuleTree(ctx context.Context, kernelVersion, osType string) error {
+	log := logr.FromContextOrDiscard(ctx)
+
+	if osType != constants.OSTypeRedHat {
+		return nil
+	}
+
+	ofedTree := filepath.Join("/lib/modules", kernelVersion, "extra", "mlnx-ofa_kernel")
+	hostModulesDir := filepath.Join("/host/lib/modules", kernelVersion)
+	hostExtraDir := filepath.Join(hostModulesDir, "extra")
+	hostOfedTree := filepath.Join(hostExtraDir, "mlnx-ofa_kernel")
+
+	if _, err := d.os.Stat(ofedTree); err != nil {
+		if _, hostErr := d.os.Stat(hostOfedTree); hostErr == nil {
+			log.V(1).Info("Container OFED module tree missing, restoring host module tree symlink", "path", ofedTree, "target", hostOfedTree)
+			return d.linkContainerOFEDTree(ctx, ofedTree, hostOfedTree)
+		}
+		log.V(1).Info("OFED module tree not found, skipping host module tree setup", "path", ofedTree, "error", err)
+		return nil
+	}
+
+	if _, err := d.os.Stat(hostModulesDir); err != nil {
+		log.V(1).Info("Host kernel module directory not found, skipping host module tree setup", "path", hostModulesDir, "error", err)
+		return nil
+	}
+
+	stdout, _, err := d.cmd.RunCommand(ctx, "readlink", "-f", ofedTree)
+	if err == nil && strings.TrimSpace(stdout) == hostOfedTree {
+		log.V(1).Info("OFED module tree already points to host module tree", "path", ofedTree, "target", hostOfedTree)
+		return nil
+	}
+
+	log.V(1).Info("Preparing host OFED module tree for SELinux module loading", "from", ofedTree, "to", hostOfedTree)
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mkdir", "-p", hostExtraDir); err != nil {
+		return fmt.Errorf("failed to create host module extra directory: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", hostOfedTree); err != nil {
+		return fmt.Errorf("failed to remove old host OFED module tree: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/"); err != nil {
+		return fmt.Errorf("failed to copy OFED module tree to host: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree); err != nil {
+		log.V(1).Info("Failed to label host OFED module tree, continuing", "path", hostOfedTree, "error", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "depmod", "-b", "/host", kernelVersion); err != nil {
+		return fmt.Errorf("failed to run host depmod: %w", err)
+	}
+
+	if err := d.linkContainerOFEDTree(ctx, ofedTree, hostOfedTree); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driverMgr) linkContainerOFEDTree(ctx context.Context, ofedTree, hostOfedTree string) error {
+	tmpOfedTree := ofedTree + ".tmp"
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)); err != nil {
+		return fmt.Errorf("failed to create container OFED module parent directory: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", tmpOfedTree); err != nil {
+		return fmt.Errorf("failed to remove stale container OFED module tree symlink: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree); err != nil {
+		return fmt.Errorf("failed to create temporary container OFED module tree symlink: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "rm", "-rf", ofedTree); err != nil {
+		return fmt.Errorf("failed to remove container OFED module tree: %w", err)
+	}
+
+	if _, _, err := d.cmd.RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree); err != nil {
+		return fmt.Errorf("failed to link container OFED module tree to host: %w", err)
+	}
+
 	return nil
 }
 
@@ -1485,16 +1609,16 @@ func (d *driverMgr) setupOpenShiftRepositories(ctx context.Context, versionInfo 
 
 	// Enable RHOCP repository
 	repoName := fmt.Sprintf("rhocp-%s-for-rhel-%d-%s-rpms", versionInfo.OpenShiftVersion, versionInfo.MajorVersion, arch)
-	_, _, err := d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-enabled", repoName)
+	_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-enabled", repoName)
 	if err != nil {
 		log.V(1).Info("Failed to enable RHOCP repository, continuing", "repo", repoName, "error", err)
 	}
 
 	// Test if makecache works
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "makecache", "--releasever="+versionInfo.FullVersion)
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, "makecache", "--releasever="+versionInfo.FullVersion)
 	if err != nil {
 		log.V(1).Info("Makecache failed, disabling RHOCP repository", "error", err)
-		_, _, _ = d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-disabled", repoName)
+		_, _, _ = d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-disabled", repoName)
 	}
 }
 
@@ -1510,7 +1634,7 @@ func (d *driverMgr) setupEUSRepositories(ctx context.Context, versionInfo *host.
 		if versionInfo.FullVersion == version {
 			log.V(1).Info("Enabling EUS repository", "version", version, "arch", arch)
 			repoName := fmt.Sprintf("rhel-%d-for-%s-baseos-eus-rpms", versionInfo.MajorVersion, arch)
-			_, _, err := d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-enabled", repoName)
+			_, _, err := d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-enabled", repoName)
 			if err != nil {
 				log.V(1).Info("Failed to enable EUS repository", "repo", repoName, "error", err)
 			}
@@ -1550,7 +1674,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 		}
 
 		for _, pkg := range packages {
-			args := []string{"dnf", "-q", "-y"}
+			args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 			if releaseverStr != "" {
 				args = append(args, releaseverStr)
 			}
@@ -1563,7 +1687,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 		}
 
 		// Install kernel-devel with --allowerasing flag
-		args := []string{"dnf", "-q", "-y"}
+		args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 		if releaseverStr != "" {
 			args = append(args, releaseverStr)
 		}
@@ -1576,7 +1700,7 @@ func (d *driverMgr) installKernelPackages(ctx context.Context, kernelVersion str
 	}
 
 	// Install kernel development and modules packages
-	args := []string{"dnf", "-q", "-y"}
+	args := []string{dnfCmd, dnfFlagQuiet, dnfFlagYes}
 	if releaseverStr != "" {
 		args = append(args, releaseverStr)
 	}
@@ -1701,9 +1825,18 @@ func (d *driverMgr) loadHostDependencies(ctx context.Context) error {
 		return fmt.Errorf("failed to read /proc/modules: %w", err)
 	}
 
+	loadedModules := make(map[string]struct{})
 	for _, line := range strings.Split(string(content), "\n") {
 		if fields := strings.Fields(line); len(fields) > 0 {
-			d.loadModuleDependencies(ctx, fields[0])
+			module := fields[0]
+			loadedModules[module] = struct{}{}
+			d.loadModuleDependencies(ctx, module)
+		}
+	}
+
+	if _, loaded := loadedModules[moduleMlx5IB]; !loaded {
+		for _, module := range []string{moduleMlx5IB, moduleMlx5Core, moduleIBCore} {
+			d.loadModuleHostInboxDependencies(ctx, module)
 		}
 	}
 	return nil
@@ -1721,6 +1854,37 @@ func (d *driverMgr) loadModuleDependencies(ctx context.Context, modName string) 
 			logr.FromContextOrDiscard(ctx).V(1).Info("Loading dependency", "dependency", dep)
 			_, _, _ = d.cmd.RunCommand(ctx, "modprobe", "-d", "/host", dep)
 		}
+	}
+}
+
+// loadModuleHostInboxDependencies preloads non-OFED dependencies through the
+// host module tree. This prevents plain modprobe calls in openibd from resolving
+// host inbox dependencies through the container-labeled /lib/modules bind.
+func (d *driverMgr) loadModuleHostInboxDependencies(ctx context.Context, modName string) {
+	log := logr.FromContextOrDiscard(ctx)
+
+	output, _, err := d.cmd.RunCommand(ctx, "modinfo", "-F", "depends", modName)
+	if err != nil {
+		return
+	}
+
+	for _, dep := range strings.Split(output, ",") {
+		dep = strings.TrimSpace(dep)
+		if dep == "" {
+			continue
+		}
+
+		hostPath, _, err := d.cmd.RunCommand(ctx, "modinfo", "-b", "/host", "-n", dep)
+		if err != nil {
+			continue
+		}
+		hostPath = strings.TrimSpace(hostPath)
+		if hostPath == "" || strings.Contains(hostPath, "/extra/mlnx-ofa_kernel/") {
+			continue
+		}
+
+		log.V(1).Info("Loading host inbox dependency", "module", modName, "dependency", dep, "path", hostPath)
+		_, _, _ = d.cmd.RunCommand(ctx, "modprobe", "-d", "/host", dep)
 	}
 }
 
@@ -1814,7 +1978,7 @@ func (d *driverMgr) printLoadedDriverVersion(ctx context.Context) error {
 	}
 
 	// Check if mlx5_core is loaded
-	if _, exists := loadedModules["mlx5_core"]; !exists {
+	if _, exists := loadedModules[moduleMlx5Core]; !exists {
 		log.V(1).Info("mlx5_core module not loaded")
 		return nil
 	}
@@ -1951,7 +2115,7 @@ func (d *driverMgr) installRedHatDependencies(ctx context.Context, versionInfo *
 	}
 
 	args := make([]string, 0, 5+len(packages))
-	args = append(args, "dnf", "-q", "-y", "--releasever="+versionInfo.FullVersion, "install")
+	args = append(args, dnfCmd, dnfFlagQuiet, dnfFlagYes, "--releasever="+versionInfo.FullVersion, "install")
 	args = append(args, packages...)
 
 	_, _, err := d.cmd.RunCommand(ctx, args[0], args[1:]...)
@@ -1960,12 +2124,12 @@ func (d *driverMgr) installRedHatDependencies(ctx context.Context, versionInfo *
 	}
 
 	// Test makecache and disable EUS if it fails
-	_, _, err = d.cmd.RunCommand(ctx, "dnf", "makecache", "--releasever="+versionInfo.FullVersion)
+	_, _, err = d.cmd.RunCommand(ctx, dnfCmd, "makecache", "--releasever="+versionInfo.FullVersion)
 	if err != nil {
 		log.V(1).Info("Makecache failed, disabling EUS repository", "error", err)
 		arch := d.getArchitecture(ctx)
 		repoName := fmt.Sprintf("rhel-%d-for-%s-baseos-eus-rpms", versionInfo.MajorVersion, arch)
-		_, _, _ = d.cmd.RunCommand(ctx, "dnf", "config-manager", "--set-disabled", repoName)
+		_, _, _ = d.cmd.RunCommand(ctx, dnfCmd, "config-manager", "--set-disabled", repoName)
 	}
 
 	return nil

--- a/entrypoint/internal/driver/driver_dtk.go
+++ b/entrypoint/internal/driver/driver_dtk.go
@@ -28,6 +28,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/internal/constants"
+	hostutils "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/host"
 )
 
 // buildDriverDTK orchestrates the driver build using the OpenShift Driver Toolkit (DTK)
@@ -51,7 +52,7 @@ func (d *driverMgr) buildDriverDTK(ctx context.Context, kernelVersion, inventory
 	if _, err := d.os.Stat(doneFlagPath); os.IsNotExist(err) {
 		log.Info("DTK build not done, setting up build")
 
-		if err := d.dtkSetupDriverBuild(ctx, dtkSharedDir, startFlagPath, doneFlagPath); err != nil {
+		if err := d.dtkSetupDriverBuild(ctx, dtkSharedDir, startFlagPath, doneFlagPath, kernelVersion); err != nil {
 			return fmt.Errorf("failed to setup DTK build: %w", err)
 		}
 
@@ -80,7 +81,7 @@ func sanitizeKernelVersion(version string) string {
 }
 
 // dtkSetupDriverBuild prepares the shared directory and script for DTK build
-func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFlagPath, doneFlagPath string) error {
+func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFlagPath, doneFlagPath, kernelVersion string) error {
 	log := logr.FromContextOrDiscard(ctx)
 	log.Info("Setting up DTK driver build", "sharedDir", sharedDir)
 
@@ -117,7 +118,10 @@ func (d *driverMgr) dtkSetupDriverBuild(ctx context.Context, sharedDir, startFla
 
 	// Create dtk.env file
 	// Get append flags
-	appendFlags := d.getAppendDriverBuildFlags(constants.OSTypeRedHat)
+	appendFlags, err := d.getDTKAppendDriverBuildFlags(ctx, kernelVersion)
+	if err != nil {
+		return err
+	}
 	appendFlagsStr := strings.Join(appendFlags, " ")
 
 	envContent := fmt.Sprintf(`export DTK_OCP_NIC_SHARED_DIR="%s"
@@ -151,6 +155,43 @@ export USE_DKMS="%v"
 	}
 
 	return nil
+}
+
+func (d *driverMgr) getDTKAppendDriverBuildFlags(ctx context.Context, kernelVersion string) ([]string, error) {
+	appendFlags := d.getAppendDriverBuildFlags(constants.OSTypeRedHat)
+	appendFlags = append(appendFlags, "--kernel", kernelVersion)
+
+	versionInfo, err := d.host.GetRedHatVersionInfo(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get RedHat version info for DTK driver build: %w", err)
+	}
+
+	distroVersion := redHatDistroVersion(versionInfo, kernelVersion)
+	if distroVersion == "" {
+		return nil, fmt.Errorf("failed to determine RHEL distro version for DTK driver build")
+	}
+
+	appendFlags = append(appendFlags, "--distro", "rhel"+distroVersion)
+	return appendFlags, nil
+}
+
+func redHatDistroVersion(versionInfo *hostutils.RedhatVersionInfo, kernelVersion string) string {
+	if versionInfo != nil {
+		if versionInfo.RHELVersion != "" {
+			return versionInfo.RHELVersion
+		}
+		if versionInfo.OpenShiftVersion == "" && versionInfo.FullVersion != "" {
+			return versionInfo.FullVersion
+		}
+	}
+
+	if matches := regexp.MustCompile(`\.el([0-9]+)_([0-9]+)`).FindStringSubmatch(kernelVersion); len(matches) == 3 {
+		return matches[1] + "." + matches[2]
+	}
+	if matches := regexp.MustCompile(`\.el([0-9]+)`).FindStringSubmatch(kernelVersion); len(matches) == 2 {
+		return matches[1]
+	}
+	return ""
 }
 
 // dtkWaitForBuild waits for the DTK build to complete

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -639,6 +639,161 @@ var _ = Describe("Driver", func() {
 		})
 	})
 
+	Context("getDistroFlagsForOS", func() {
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+		})
+
+		It("should pass explicit distro for RedHat", func() {
+			versionInfo := &host.RedhatVersionInfo{
+				MajorVersion:     9,
+				FullVersion:      "9.8",
+				OpenShiftVersion: "",
+			}
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil)
+
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(flags).To(Equal([]string{"--distro", "rhel9.8"}))
+		})
+
+		It("should not pass explicit distro for OpenShift", func() {
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeOpenShift)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(flags).To(BeEmpty())
+		})
+
+		It("should return RedHat version errors", func() {
+			expectedError := errors.New("failed to parse version")
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(nil, expectedError)
+
+			flags, err := dm.getDistroFlagsForOS(ctx, constants.OSTypeRedHat)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to get RedHat version info for driver build"))
+			Expect(flags).To(BeNil())
+		})
+	})
+
+	Context("ensureRedHatHostModuleTree", func() {
+		const kernelVersion = "5.14.0-687.5.3.el9_8.x86_64"
+
+		var (
+			ofedTree       string
+			hostModulesDir string
+			hostExtraDir   string
+			hostOfedTree   string
+		)
+
+		BeforeEach(func() {
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+			ofedTree = filepath.Join("/lib/modules", kernelVersion, "extra", "mlnx-ofa_kernel")
+			hostModulesDir = filepath.Join("/host/lib/modules", kernelVersion)
+			hostExtraDir = filepath.Join(hostModulesDir, "extra")
+			hostOfedTree = filepath.Join(hostExtraDir, "mlnx-ofa_kernel")
+		})
+
+		It("should skip non-RedHat systems", func() {
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeOpenShift)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the container OFED tree is missing", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat(hostOfedTree).Return(nil, os.ErrNotExist)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should restore the symlink when the container OFED tree is missing but the host tree exists", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			osMock.EXPECT().Stat(ofedTree).Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat(hostOfedTree).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the host module tree is missing", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, os.ErrNotExist)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should skip when the OFED tree already resolves to the host tree", func() {
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(hostOfedTree+"\n", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should copy, relabel, and link the OFED tree through the host module tree", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should continue when relabeling fails", func() {
+			tmpOfedTree := ofedTree + ".tmp"
+			expectedError := errors.New("chcon failed")
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", expectedError)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", filepath.Dir(ofedTree)).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "ln", "-s", hostOfedTree, tmpOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", ofedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mv", "-T", tmpOfedTree, ofedTree).Return("", "", nil)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return an error when host depmod fails", func() {
+			expectedError := errors.New("depmod failed")
+			osMock.EXPECT().Stat(ofedTree).Return(nil, nil)
+			osMock.EXPECT().Stat(hostModulesDir).Return(nil, nil)
+			cmdMock.EXPECT().RunCommand(ctx, "readlink", "-f", ofedTree).Return(ofedTree+"\n", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", hostExtraDir).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "rm", "-rf", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "cp", "-a", ofedTree, hostExtraDir+"/").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "chcon", "-R", "-t", "modules_object_t", hostOfedTree).Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "depmod", "-b", "/host", kernelVersion).Return("", "", expectedError)
+
+			err := dm.ensureRedHatHostModuleTree(ctx, kernelVersion, constants.OSTypeRedHat)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to run host depmod"))
+		})
+	})
+
 	Context("getAppendDriverBuildFlags", func() {
 		BeforeEach(func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
@@ -1028,11 +1183,11 @@ var _ = Describe("Driver", func() {
 			checksumPath := inventoryPath + ".checksum"
 			buildConfigPath := inventoryPath + ".buildconfig"
 
-			osMock.EXPECT().Stat(inventoryPath).Return(nil, nil)                             // inventory dir exists
-			osMock.EXPECT().Stat(checksumPath).Return(nil, nil)                              // checksum file exists
-			osMock.EXPECT().ReadFile(checksumPath).Return([]byte("abc123"), nil)             // stored checksum
+			osMock.EXPECT().Stat(inventoryPath).Return(nil, nil)                                  // inventory dir exists
+			osMock.EXPECT().Stat(checksumPath).Return(nil, nil)                                   // checksum file exists
+			osMock.EXPECT().ReadFile(checksumPath).Return([]byte("abc123"), nil)                  // stored checksum
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("abc123", "", nil) // computed checksum matches
-			osMock.EXPECT().Stat(buildConfigPath).Return(nil, os.ErrNotExist)                // .buildconfig absent → old cache
+			osMock.EXPECT().Stat(buildConfigPath).Return(nil, os.ErrNotExist)                     // .buildconfig absent → old cache
 
 			shouldBuild, path, err := dm.checkDriverInventory(ctx, "5.4.0-42-generic")
 			Expect(err).NotTo(HaveOccurred())
@@ -1071,15 +1226,15 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// UseDKMS false by default → install.pl must include --without-dkms
+			// UseDKMS false by default → install.pl must include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
@@ -1132,15 +1287,15 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// UseDKMS true → install.pl must NOT include --without-dkms
+			// UseDKMS true → install.pl must NOT include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
 				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
@@ -1188,14 +1343,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-default", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeSLES, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		// This will cause checkDriverInventory to return true
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			// This will cause checkDriverInventory to return true
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installSLESPrerequisites
+			// Mock installSLESPrerequisites
 			cmdMock.EXPECT().RunCommand(ctx, "zypper", "--non-interactive", "install", "--no-recommends", "kernel-default-devel=5.4.0-42").Return("", "", nil)
 
 			// Mock buildDriverFromSource - SLES specific arguments
@@ -1241,20 +1396,20 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeRedHat, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		// This will cause checkDriverInventory to return true
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			// This will cause checkDriverInventory to return true
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installRedHatPrerequisites
-		versionInfo := &host.RedhatVersionInfo{
-			MajorVersion:     8,
-			FullVersion:      "8.4",
-			OpenShiftVersion: "",
+			// Mock installRedHatPrerequisites
+			versionInfo := &host.RedhatVersionInfo{
+				MajorVersion:     8,
+				FullVersion:      "8.4",
+				OpenShiftVersion: "",
 			}
-			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(versionInfo, nil).Twice()
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "dnf", "config-manager", "--set-enabled", "rhel-8-for-x86_64-baseos-eus-rpms").Return("", "", nil)
 			osMock.EXPECT().Stat("/lib/modules/5.4.0-42/build").Return(nil, os.ErrNotExist)
@@ -1273,6 +1428,7 @@ var _ = Describe("Driver", func() {
 				"--with-mlnx-tools", "--without-knem", "--without-iser",
 				"--without-isert", "--without-srp", "--without-kernel-mft",
 				"--without-mlnx-rdma-rxe", "--disable-kmp", "--without-dkms",
+				"--distro", "rhel8.4",
 				"--without-xpmem", "--without-xpmem-modules",
 				"--without-mlnx-nfsrdma",
 				"--without-mlnx-nvme").Return("", "", nil)
@@ -1299,6 +1455,8 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42/modules.builtin").Return("", "", nil)
 			// Mock RedHat driver installation
 			cmdMock.EXPECT().RunCommand(ctx, "rpm", "-ivh", "--replacepkgs", "--nodeps", mock.Anything).Return("", "", nil)
+			osMock.EXPECT().Stat("/lib/modules/5.4.0-42/extra/mlnx-ofa_kernel").Return(nil, os.ErrNotExist)
+			osMock.EXPECT().Stat("/host/lib/modules/5.4.0-42/extra/mlnx-ofa_kernel").Return(nil, os.ErrNotExist)
 			cmdMock.EXPECT().RunCommand(ctx, "depmod", "5.4.0-42").Return("", "", nil)
 
 			err := dm.Build(ctx)
@@ -1309,14 +1467,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeOpenShift, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		// This will cause checkDriverInventory to return true
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			// This will cause checkDriverInventory to return true
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installRedHatPrerequisites for OpenShift
+			// Mock installRedHatPrerequisites for OpenShift
 			versionInfo := &host.RedhatVersionInfo{
 				MajorVersion:     8,
 				FullVersion:      "8.4",
@@ -1390,14 +1548,14 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.14.0-570.78.1.el9_6.x86_64", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeOpenShift, nil)
 
-		// No NvidiaNicDriversInventoryPath set → checkDriverInventory returns
-		// shouldBuild=true immediately, without any Stat/ReadFile calls.
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// No NvidiaNicDriversInventoryPath set → checkDriverInventory returns
+			// shouldBuild=true immediately, without any Stat/ReadFile calls.
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// DTK setup: done flag absent, then MkdirAll fails — keeps the mock surface
-		// minimal without having to wire up the entire DTK pipeline.
-		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // done flag not present
-		osMock.EXPECT().MkdirAll(mock.Anything, mock.Anything).Return(errors.New("mkdir failed"))
+			// DTK setup: done flag absent, then MkdirAll fails — keeps the mock surface
+			// minimal without having to wire up the entire DTK pipeline.
+			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // done flag not present
+			osMock.EXPECT().MkdirAll(mock.Anything, mock.Anything).Return(errors.New("mkdir failed"))
 
 			err := dm.Build(ctx)
 			Expect(err).To(HaveOccurred())
@@ -1412,10 +1570,10 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock createInventoryDirectory failure
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
-		expectedError := errors.New("mkdir failed")
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", expectedError)
+			// Mock createInventoryDirectory failure
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			expectedError := errors.New("mkdir failed")
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", expectedError)
 
 			err := dm.Build(ctx)
 			Expect(err).To(HaveOccurred())
@@ -1442,15 +1600,15 @@ var _ = Describe("Driver", func() {
 			// Mock checkDriverInventory to return true (build needed) - no inventory path set
 			// This will cause checkDriverInventory to return true
 
-		// Mock createInventoryDirectory
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock buildDriverFromSource failure - Ubuntu specific arguments
+			// Mock buildDriverFromSource failure - Ubuntu specific arguments
 			expectedError := errors.New("install.pl failed")
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
@@ -1476,28 +1634,28 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
-		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
+			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock buildDriverFromSource - Ubuntu specific arguments
-		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-			"--without-xpmem", "--without-xpmem-modules",
-			"--without-mlnx-nfsrdma-modules",
-			"--without-mlnx-nvme-modules").Return("", "", nil)
+			// Mock buildDriverFromSource - Ubuntu specific arguments
+			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+				"--without-xpmem", "--without-xpmem-modules",
+				"--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-nvme-modules").Return("", "", nil)
 
-		// Mock copyBuildArtifacts failure - debug logging and copy failure
+			// Mock copyBuildArtifacts failure - debug logging and copy failure
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.MatchedBy(func(cmd string) bool {
 				return strings.Contains(cmd, "ls -la") && strings.Contains(cmd, "DEBS")
@@ -1529,29 +1687,29 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
 			// Mock checkDriverInventory to return true (build needed) - inventory directory doesn't exist
-		osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			osMock.EXPECT().Stat(mock.Anything).Return(nil, os.ErrNotExist) // inventory directory doesn't exist
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock buildDriverFromSource - Ubuntu specific arguments
-		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-			"--without-xpmem", "--without-xpmem-modules",
-			"--without-mlnx-nfsrdma-modules",
-			"--without-mlnx-nvme-modules").Return("", "", nil)
+			// Mock buildDriverFromSource - Ubuntu specific arguments
+			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+				"--without-xpmem", "--without-xpmem-modules",
+				"--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-nvme-modules").Return("", "", nil)
 
-		// Mock copyBuildArtifacts - debug logging and copy
-		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil).Times(4)
+			// Mock copyBuildArtifacts - debug logging and copy
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil).Times(4)
 
 			// Mock fixSourceLink
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
@@ -1575,39 +1733,39 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		// This will cause checkDriverInventory to return true
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			// This will cause checkDriverInventory to return true
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock buildDriverFromSource - Ubuntu specific arguments
-		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-			"--without-xpmem", "--without-xpmem-modules",
-			"--without-mlnx-nfsrdma-modules",
-			"--without-mlnx-nvme-modules").Return("", "", nil)
+			// Mock buildDriverFromSource - Ubuntu specific arguments
+			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+				"--without-xpmem", "--without-xpmem-modules",
+				"--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-nvme-modules").Return("", "", nil)
 
-		// Mock copyBuildArtifacts - debug logging and copy
-		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
+			// Mock copyBuildArtifacts - debug logging and copy
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
 
-		// Note: storeBuildChecksum is not called when NvidiaNicDriversInventoryPath is empty
+			// Note: storeBuildChecksum is not called when NvidiaNicDriversInventoryPath is empty
 
-		// Mock fixSourceLink failure (should not cause build to fail)
-		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-		expectedError := errors.New("readlink failed")
+			// Mock fixSourceLink failure (should not cause build to fail)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			expectedError := errors.New("readlink failed")
 			osMock.EXPECT().Readlink(mock.Anything).Return("", expectedError)
 
 			// Mock installDriver - check if kernel modules directory exists
@@ -1653,45 +1811,45 @@ var _ = Describe("Driver", func() {
 			hostMock.EXPECT().GetKernelVersion(ctx).Return("5.4.0-42-generic", nil)
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
 
-		// Mock checkDriverInventory to return true (build needed) - no inventory path set
-		// This will cause checkDriverInventory to return true
-		osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
+			// Mock checkDriverInventory to return true (build needed) - no inventory path set
+			// This will cause checkDriverInventory to return true
+			osMock.EXPECT().RemoveAll(mock.Anything).Return(nil)
 
-		// Mock createInventoryDirectory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
+			// Mock createInventoryDirectory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", mock.Anything).Return("", "", nil)
 
-		// Mock installUbuntuPrerequisites
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
+			// Mock installUbuntuPrerequisites
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "-yq", "install", "pkg-config", "linux-headers-5.4.0-42-generic").Return("", "", nil)
 
-		// Mock buildDriverFromSource - Ubuntu specific arguments
-		cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
-			"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-			"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-			"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-			"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
-			"--without-xpmem", "--without-xpmem-modules",
-			"--without-mlnx-nfsrdma-modules",
-			"--without-mlnx-nvme-modules").Return("", "", nil)
+			// Mock buildDriverFromSource - Ubuntu specific arguments
+			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
+				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
+				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
+				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
+				"--without-mlnx-rdma-rxe-modules", "--disable-kmp", "--without-dkms",
+				"--without-xpmem", "--without-xpmem-modules",
+				"--without-mlnx-nfsrdma-modules",
+				"--without-mlnx-nvme-modules").Return("", "", nil)
 
-		// Mock copyBuildArtifacts - debug logging and copy
-		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
-		cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
+			// Mock copyBuildArtifacts - debug logging and copy
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la source directory
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // find .deb files
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // ls -la destination directory
+			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil) // cp command
 
-		// Mock fixSourceLink
-		cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
-		osMock.EXPECT().Readlink(mock.Anything).Return("", errors.New("not found"))
+			// Mock fixSourceLink
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			osMock.EXPECT().Readlink(mock.Anything).Return("", errors.New("not found"))
 
-		// Mock installDriver - check if kernel modules directory exists
-		osMock.EXPECT().Stat("/lib/modules/5.4.0-42-generic").Return(nil, os.ErrNotExist)
-		// Mock creating kernel modules directory
-		cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", "/lib/modules/5.4.0-42-generic").Return("", "", nil)
-		// Mock creating modules.order and modules.builtin files
-		cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.order").Return("", "", nil)
-		cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.builtin").Return("", "", nil)
+			// Mock installDriver - check if kernel modules directory exists
+			osMock.EXPECT().Stat("/lib/modules/5.4.0-42-generic").Return(nil, os.ErrNotExist)
+			// Mock creating kernel modules directory
+			cmdMock.EXPECT().RunCommand(ctx, "mkdir", "-p", "/lib/modules/5.4.0-42-generic").Return("", "", nil)
+			// Mock creating modules.order and modules.builtin files
+			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.order").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "touch", "/lib/modules/5.4.0-42-generic/modules.builtin").Return("", "", nil)
 			// Mock Ubuntu driver installation
 			cmdMock.EXPECT().RunCommand(ctx, "apt-get", "update").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "sh", "-c", mock.Anything).Return("", "", nil)
@@ -2322,6 +2480,31 @@ var _ = Describe("Driver", func() {
 			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("macsec", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "macsec").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", errors.New("not found"))
+
+			err := dm.restartDriver(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should preload host inbox dependencies when mlx5_ib is not loaded yet", func() {
+			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx_compat 12288 0 - Live 0xffff\n"), nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx_compat").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("mlx5_core,mlx_compat,ib_core,ib_uverbs,macsec", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx5_core").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "ib_core").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/infiniband/core/ib_core.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "ib_uverbs").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/drivers/infiniband/core/ib_uverbs.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "macsec").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/kernel/drivers/net/macsec.ko.xz", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "macsec").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_core").Return("tls,mlx_compat", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "tls").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/kernel/net/tls/tls.ko.xz", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "tls").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "ib_core").Return("mlx_compat", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-b", "/host", "-n", "mlx_compat").Return("/host/lib/modules/6.12.0-211.31.1.el10_2.x86_64/extra/mlnx-ofa_kernel/compat/mlx_compat.ko", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
@@ -3955,8 +4138,8 @@ var _ = Describe("Driver OFED Blacklist", func() {
 		It("should not include third-party RDMA modules section when flag is false", func() {
 			blacklistFile := filepath.Join(tempDir, "no-third-party-rdma-blacklist.conf")
 			cfg := config.Config{
-				OfedBlacklistModulesFile:     blacklistFile,
-				OfedBlacklistModules:         []string{"mlx5_core", "mlx5_ib"},
+				OfedBlacklistModulesFile:    blacklistFile,
+				OfedBlacklistModules:        []string{"mlx5_core", "mlx5_ib"},
 				UnloadThirdPartyRdmaModules: false,
 			}
 

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -4458,13 +4458,15 @@ var _ = Describe("Driver OFED Blacklist", func() {
 
 var _ = Describe("Driver DTK setup", func() {
 	var (
-		cmdMock *cmdMockPkg.Interface
-		ctx     context.Context
-		tempDir string
+		cmdMock  *cmdMockPkg.Interface
+		hostMock *hostMockPkg.Interface
+		ctx      context.Context
+		tempDir  string
 	)
 
 	BeforeEach(func() {
 		cmdMock = cmdMockPkg.NewInterface(GinkgoT())
+		hostMock = hostMockPkg.NewInterface(GinkgoT())
 		ctx = context.Background()
 		tempDir = GinkgoT().TempDir()
 	})
@@ -4489,20 +4491,28 @@ var _ = Describe("Driver DTK setup", func() {
 				UseDKMS:             true,
 				EnableNfsRdma:       true,
 			}
-			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, host: hostMock, os: wrappers.NewOS()}
 
 			sharedDir := filepath.Join(tempDir, "dkms-true")
 			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
 			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+			kernelVersion := "5.14.0-687.13.1.el9_8.x86_64"
 
 			mockCpCalls(dm, sharedDir)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(&host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				RHELVersion:      "9.8",
+				OpenShiftVersion: "4.18",
+			}, nil)
 
-			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath, kernelVersion)
 			Expect(err).NotTo(HaveOccurred())
 
 			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="true"`))
+			Expect(string(content)).To(ContainSubstring(`export APPEND_DRIVER_BUILD_FLAGS="--kernel 5.14.0-687.13.1.el9_8.x86_64 --distro rhel9.8"`))
 			// Sanity-check that other required fields are also present
 			Expect(string(content)).To(ContainSubstring(`export USE_NEW_ENTRYPOINT="true"`))
 			Expect(string(content)).To(ContainSubstring(`export NVIDIA_NIC_DRIVER_VER="26.04-0.5.3.0"`))
@@ -4515,20 +4525,37 @@ var _ = Describe("Driver DTK setup", func() {
 				UseDKMS:             false,
 				EnableNfsRdma:       true,
 			}
-			dm := &driverMgr{cfg: cfg, cmd: cmdMock, os: wrappers.NewOS()}
+			dm := &driverMgr{cfg: cfg, cmd: cmdMock, host: hostMock, os: wrappers.NewOS()}
 
 			sharedDir := filepath.Join(tempDir, "dkms-false")
 			startFlagPath := filepath.Join(sharedDir, "dtk_start_compile")
 			doneFlagPath := filepath.Join(sharedDir, "dtk_done_compile_ver")
+			kernelVersion := "5.14.0-687.13.1.el9_8.x86_64"
 
 			mockCpCalls(dm, sharedDir)
+			hostMock.EXPECT().GetRedHatVersionInfo(ctx).Return(&host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				RHELVersion:      "9.8",
+				OpenShiftVersion: "4.18",
+			}, nil)
 
-			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath)
+			err := dm.dtkSetupDriverBuild(ctx, sharedDir, startFlagPath, doneFlagPath, kernelVersion)
 			Expect(err).NotTo(HaveOccurred())
 
 			content, err := os.ReadFile(filepath.Join(sharedDir, "dtk.env"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(ContainSubstring(`export USE_DKMS="false"`))
+		})
+
+		It("should derive DTK distro version from kernel when RHCOS does not expose RHEL_VERSION", func() {
+			versionInfo := &host.RedhatVersionInfo{
+				MajorVersion:     4,
+				FullVersion:      "4.18",
+				OpenShiftVersion: "4.18",
+			}
+
+			Expect(redHatDistroVersion(versionInfo, "5.14.0-687.13.1.el9_8.x86_64")).To(Equal("9.8"))
 		})
 	})
 })

--- a/entrypoint/internal/dtk/build_test.go
+++ b/entrypoint/internal/dtk/build_test.go
@@ -32,7 +32,6 @@ import (
 	cmdMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
 )
 
-
 func TestRunBuild(t *testing.T) {
 	log := logr.Discard()
 	tempDir := t.TempDir()
@@ -75,6 +74,7 @@ func TestRunBuild(t *testing.T) {
 	t.Run("should wait for start flag and run build without dkms", func(t *testing.T) {
 		cfgNoDKMS := cfg
 		cfgNoDKMS.UseDKMS = false
+		cfgNoDKMS.AppendDriverBuildFlags = "--kernel 5.14.0-687.13.1.el9_8.x86_64 --distro rhel9.8"
 
 		cmdMock := cmdMockPkg.NewInterface(t)
 		cmdMock.EXPECT().RunCommand(mock.Anything, "dnf", "install", "-y", "perl").Return("", "", nil)
@@ -93,7 +93,8 @@ func TestRunBuild(t *testing.T) {
 		cmdMock.EXPECT().RunCommand(mock.Anything, expectedInstallScript,
 			"--build-only", "--kernel-only", "--without-knem", "--without-iser", "--without-isert",
 			"--without-srp", "--with-mlnx-tools", "--with-ofed-scripts", "--copy-ifnames-udev",
-			"--disable-kmp", "--without-dkms").Return("", "", nil)
+			"--disable-kmp", "--without-dkms", "--kernel", "5.14.0-687.13.1.el9_8.x86_64",
+			"--distro", "rhel9.8").Return("", "", nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		errCh := make(chan error)

--- a/entrypoint/internal/utils/host/host.go
+++ b/entrypoint/internal/utils/host/host.go
@@ -43,6 +43,9 @@ type RedhatVersionInfo struct {
 	MajorVersion int
 	// FullVersion is the complete version string (e.g., "8.4", "9.2")
 	FullVersion string
+	// RHELVersion is the underlying RHEL version when it is distinct from
+	// FullVersion, such as RHCOS hosts where FullVersion is OpenShift 4.x.
+	RHELVersion string
 	// OpenShiftVersion is the OpenShift version if running on RHCOS (e.g., "4.9")
 	// If empty, this is not RHCOS
 	OpenShiftVersion string
@@ -290,6 +293,7 @@ func (h *host) buildRedHatVersionCache() {
 			versionInfo.OpenShiftVersion = constants.DefaultOpenShiftVersion
 		}
 		versionInfo.FullVersion = versionInfo.OpenShiftVersion
+		versionInfo.RHELVersion = rhelVersion
 	} else {
 		// For RHEL and other RedHat-based distros (CentOS, Fedora, etc.)
 		versionInfo.FullVersion = rhelVersion
@@ -304,6 +308,7 @@ func (h *host) buildRedHatVersionCache() {
 		if openshiftVersion != "" {
 			versionInfo.OpenShiftVersion = openshiftVersion
 		}
+		versionInfo.RHELVersion = versionInfo.FullVersion
 	}
 
 	// Extract major version from full version

--- a/entrypoint/internal/utils/host/host_test.go
+++ b/entrypoint/internal/utils/host/host_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/Mellanox/doca-driver-build/entrypoint/internal/constants"
 	cmd_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
- 	wrappers_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/wrappers/mocks"
+	wrappers_mocks "github.com/Mellanox/doca-driver-build/entrypoint/internal/wrappers/mocks"
 )
 
 var _ = Describe("Host", func() {
@@ -36,7 +36,7 @@ var _ = Describe("Host", func() {
 		h       Interface
 		ctx     context.Context
 	)
-	
+
 	BeforeEach(func() {
 		cmdMock = cmd_mocks.NewInterface(GinkgoT())
 		osMock = wrappers_mocks.NewOSWrapper(GinkgoT())
@@ -746,6 +746,7 @@ PRETTY_NAME="Red Hat Enterprise Linux 9.2 (Plow)"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(9))
 			Expect(versionInfo.FullVersion).To(Equal("9.2"))
+			Expect(versionInfo.RHELVersion).To(Equal("9.2"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 
@@ -765,6 +766,7 @@ PRETTY_NAME="Red Hat Enterprise Linux 8.4 (Ootpa)"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(8))
 			Expect(versionInfo.FullVersion).To(Equal("8.4"))
+			Expect(versionInfo.RHELVersion).To(Equal("8.4"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 
@@ -859,6 +861,7 @@ OSTREE_VERSION="418.94.202506251005-0"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(4))
 			Expect(versionInfo.FullVersion).To(Equal("4.18"))
+			Expect(versionInfo.RHELVersion).To(Equal("9.4"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal("4.18"))
 		})
 
@@ -876,6 +879,7 @@ RHEL_VERSION="9.2.1"`
 			Expect(err).ToNot(HaveOccurred())
 			Expect(versionInfo.MajorVersion).To(Equal(9))
 			Expect(versionInfo.FullVersion).To(Equal("9.2.1")) // RHEL_VERSION takes precedence
+			Expect(versionInfo.RHELVersion).To(Equal("9.2.1"))
 			Expect(versionInfo.OpenShiftVersion).To(Equal(""))
 		})
 


### PR DESCRIPTION
## Summary

Backports the RHEL driver build fixes to the `network-operator-26.4.x` branch as one PR with two cherry-picked commits:

- `Fix RHEL driver module loading from container`
- `Fix OpenShift DTK RHEL driver build flags`

## What Changed

- Pass explicit `--distro rhel<version>` to `install.pl` for plain RHEL source builds.
- Prepare RHEL OFED kernel modules through the host module tree so module loading resolves from `/host/lib/modules`, including host `depmod` and best-effort SELinux module labeling.
- Preserve the existing 26.4 host dependency preload path for inbox dependencies such as `macsec`.
- Pass explicit `--kernel` and `--distro` build flags into the OpenShift DTK build flow so `install.pl` does not rely on DTK container OS auto-detection.
- Track the underlying RHEL version separately from the OpenShift/RHCOS version when parsing host release metadata.

## Verification

- `bash -n entrypoint.sh`
- `git diff --check upstream/network-operator-26.4.x...HEAD`
- `GOCACHE=/private/tmp/doca-driver-build-go-cache-26-4 GOMODCACHE=/private/tmp/doca-driver-build-go-mod-26-4 go test ./internal/driver/... ./internal/dtk/... ./internal/utils/host/...`

Notes:

- `go build ./...` from `entrypoint/` still hits the pre-existing `sriovnet`/`netlink` dependency issue documented for this repo.
- This worktree does not contain `entrypoint/bin/golangci-lint`, so scoped lint could not be run locally.
