### PR TITLE
fix: use DKMS package suffix for Ubuntu builds

### DIFF
--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -1619,10 +1619,15 @@ func (d *driverMgr) ubuntuSyncNetworkConfigurationTools(ctx context.Context) err
 	return nil
 }
 
-// getPackageSuffix returns the package suffix based on OS type
+// getPackageSuffix returns the package suffix based on OS type and build mode.
+// Ubuntu's install.pl uses distinct package names for DKMS and non-DKMS builds,
+// so exclusion flags must target the package variant selected by USE_DKMS.
 func (d *driverMgr) getPackageSuffix(osType string) string {
 	switch osType {
 	case constants.OSTypeUbuntu:
+		if d.cfg.UseDKMS {
+			return "-dkms"
+		}
 		return "-modules"
 	case constants.OSTypeSLES, constants.OSTypeRedHat, constants.OSTypeOpenShift:
 		return ""

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -551,9 +551,17 @@ var _ = Describe("Driver", func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 		})
 
-		It("should return -modules for Ubuntu", func() {
+		It("should return -modules for Ubuntu when DKMS is disabled", func() {
 			suffix := dm.getPackageSuffix(constants.OSTypeUbuntu)
 			Expect(suffix).To(Equal("-modules"))
+		})
+
+		It("should return -dkms for Ubuntu when DKMS is enabled", func() {
+			cfg.UseDKMS = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			suffix := dm.getPackageSuffix(constants.OSTypeUbuntu)
+			Expect(suffix).To(Equal("-dkms"))
 		})
 
 		It("should return empty string for SLES", func() {
@@ -807,6 +815,18 @@ var _ = Describe("Driver", func() {
 			Expect(flags).To(Equal([]string{
 				"--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules",
+			}))
+		})
+
+		It("should return DKMS package flags when EnableNfsRdma is false for Ubuntu with DKMS enabled", func() {
+			cfg.EnableNfsRdma = false
+			cfg.UseDKMS = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			flags := dm.getAppendDriverBuildFlags(constants.OSTypeUbuntu)
+			Expect(flags).To(Equal([]string{
+				"--without-mlnx-nfsrdma-dkms",
+				"--without-mlnx-nvme-dkms",
 			}))
 		})
 
@@ -1298,12 +1318,12 @@ var _ = Describe("Driver", func() {
 			// UseDKMS true → install.pl must NOT include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp",
+				"--with-mlnx-tools", "--without-knem-dkms", "--without-iser-dkms",
+				"--without-isert-dkms", "--without-srp-dkms", "--without-kernel-mft-dkms",
+				"--without-mlnx-rdma-rxe-dkms", "--disable-kmp",
 				"--without-xpmem", "--without-xpmem-modules", "--without-xpmem-dkms",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+				"--without-mlnx-nfsrdma-dkms",
+				"--without-mlnx-nvme-dkms").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)


### PR DESCRIPTION
## Summary

- select Ubuntu package exclusion suffixes from `USE_DKMS`
- invalidate persistent inventories created with the old package selection
- add regression coverage for DKMS flags and cache migration

## Why

Ubuntu DKMS builds select packages ending in `-dkms`, while the entrypoint
generated `--without-*-modules` exclusions. This allowed storage DKMS packages,
including `mlnx-nvme-dkms`, to remain in the build. After a node reboot the NVMe
module could keep `mlx_compat` in use, preventing `openibd` from fully unloading
the previous mlx5 stack and causing the auxiliary `mlx5_fwctl` reload to fail.

The inventory fingerprint is versioned because replacing the entrypoint under
the same driver version would otherwise reuse the incorrectly built packages.

## Validation

- `go test ./internal/driver/... -v` — 229 specs passed
- complete `go test ./...` in a Go 1.26 Linux/amd64 container
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...`
- `golangci-lint` v2.12.2 — 0 issues

Test image:

`harbor.mellanox.com/cloud-orchestration-dev/doca-driver:doca3.5.0-26.07-0.5.1.0-0-ubuntu26.04-amd64`

Digest: `sha256:33e6202a3ff11c9f9a47115f9e71144be579020ede0bbca36db139368af77f33`

Closes #424
