### PR TITLE
fix: use DKMS package suffix for Ubuntu builds

### DIFF
--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -1619,10 +1619,15 @@ func (d *driverMgr) ubuntuSyncNetworkConfigurationTools(ctx context.Context) err
 	return nil
 }
 
-// getPackageSuffix returns the package suffix based on OS type
+// getPackageSuffix returns the package suffix based on OS type and build mode.
+// Ubuntu's install.pl uses distinct package names for DKMS and non-DKMS builds,
+// so exclusion flags must target the package variant selected by USE_DKMS.
 func (d *driverMgr) getPackageSuffix(osType string) string {
 	switch osType {
 	case constants.OSTypeUbuntu:
+		if d.cfg.UseDKMS {
+			return "-dkms"
+		}
 		return "-modules"
 	case constants.OSTypeSLES, constants.OSTypeRedHat, constants.OSTypeOpenShift:
 		return ""

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -551,9 +551,17 @@ var _ = Describe("Driver", func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
 		})
 
-		It("should return -modules for Ubuntu", func() {
+		It("should return -modules for Ubuntu when DKMS is disabled", func() {
 			suffix := dm.getPackageSuffix(constants.OSTypeUbuntu)
 			Expect(suffix).To(Equal("-modules"))
+		})
+
+		It("should return -dkms for Ubuntu when DKMS is enabled", func() {
+			cfg.UseDKMS = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			suffix := dm.getPackageSuffix(constants.OSTypeUbuntu)
+			Expect(suffix).To(Equal("-dkms"))
 		})
 
 		It("should return empty string for SLES", func() {
@@ -807,6 +815,18 @@ var _ = Describe("Driver", func() {
 			Expect(flags).To(Equal([]string{
 				"--without-mlnx-nfsrdma-modules",
 				"--without-mlnx-nvme-modules",
+			}))
+		})
+
+		It("should return DKMS package flags when EnableNfsRdma is false for Ubuntu with DKMS enabled", func() {
+			cfg.EnableNfsRdma = false
+			cfg.UseDKMS = true
+			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+
+			flags := dm.getAppendDriverBuildFlags(constants.OSTypeUbuntu)
+			Expect(flags).To(Equal([]string{
+				"--without-mlnx-nfsrdma-dkms",
+				"--without-mlnx-nvme-dkms",
 			}))
 		})
 
@@ -1298,12 +1318,12 @@ var _ = Describe("Driver", func() {
 			// UseDKMS true → install.pl must NOT include --without-dkms
 			cmdMock.EXPECT().RunCommand(ctx, "/test/driver/path/install.pl",
 				"--without-depcheck", "--kernel", "5.4.0-42-generic", "--kernel-only", "--build-only",
-				"--with-mlnx-tools", "--without-knem-modules", "--without-iser-modules",
-				"--without-isert-modules", "--without-srp-modules", "--without-kernel-mft-modules",
-				"--without-mlnx-rdma-rxe-modules", "--disable-kmp",
+				"--with-mlnx-tools", "--without-knem-dkms", "--without-iser-dkms",
+				"--without-isert-dkms", "--without-srp-dkms", "--without-kernel-mft-dkms",
+				"--without-mlnx-rdma-rxe-dkms", "--disable-kmp",
 				"--without-xpmem", "--without-xpmem-modules", "--without-xpmem-dkms",
-				"--without-mlnx-nfsrdma-modules",
-				"--without-mlnx-nvme-modules").Return("", "", nil)
+				"--without-mlnx-nfsrdma-dkms",
+				"--without-mlnx-nvme-dkms").Return("", "", nil)
 
 			// Mock copyBuildArtifacts - debug logging and copy
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)


### PR DESCRIPTION
Ubuntu DKMS builds select package names ending in -dkms, but the generated exclusion flags used the non-DKMS -modules suffix. This left storage DKMS packages installed and could prevent openibd from unloading mlx_compat after a reboot.

Select the package suffix from the build mode so install.pl excludes the package variants used by each Ubuntu build type.


(cherry picked from commit bcd949a044553c36ba12a2957a45c17918beeefd)