### PR TITLE
fix: unload nvidia_peermem at the driver restart boundary

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -751,6 +751,7 @@ function restart_driver() {
     ${UNLOAD_STORAGE_MODULES} && unload_storage_modules
     ${UNLOAD_THIRD_PARTY_RDMA_MODULES} && unload_third_party_rdma_modules
     unload_mlx5_auxiliary_modules
+    unload_blocking_modules
 
     exec_cmd "/etc/init.d/openibd restart"
 
@@ -1957,8 +1958,6 @@ if [ -z "${NVIDIA_NIC_DRIVER_VER}" ]; then
 fi
 
 timestamp_print "Container full version: ${NVIDIA_NIC_DRIVER_VER}-${NVIDIA_NIC_CONTAINER_VER}"
-
-unload_blocking_modules
 
 storage_modules_loaded=$(lsmod | egrep 'ib_isert|nvme_rdma|nvmet_rdma|rpcrdma|xprtrdma|ib_srpt' -c)
 

--- a/entrypoint/internal/driver/driver.go
+++ b/entrypoint/internal/driver/driver.go
@@ -48,6 +48,7 @@ const (
 	moduleIBCore   = "ib_core"
 	moduleMlx5Core = "mlx5_core"
 	moduleMlx5IB   = "mlx5_ib"
+	modulePeerMem  = "nvidia_peermem"
 )
 
 var kernelModuleNamePattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_-]*$`)
@@ -1972,6 +1973,9 @@ func (d *driverMgr) restartDriver(ctx context.Context) error {
 	}
 
 	unloadedMlx5AuxiliaryModules := d.unloadMlx5AuxiliaryModules(ctx)
+	if err := d.unloadNvidiaPeermem(ctx); err != nil {
+		return err
+	}
 
 	// Restart openibd service
 	_, _, err := d.cmd.RunCommand(ctx, "/etc/init.d/openibd", "restart")
@@ -1982,6 +1986,31 @@ func (d *driverMgr) restartDriver(ctx context.Context) error {
 	if err := d.loadMlx5AuxiliaryModules(ctx, unloadedMlx5AuxiliaryModules); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// unloadNvidiaPeermem unloads nvidia_peermem immediately before openibd
+// replaces the OFED modules it depends on.
+func (d *driverMgr) unloadNvidiaPeermem(ctx context.Context) error {
+	log := logr.FromContextOrDiscard(ctx)
+	loadedModules, err := d.host.LsMod(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list loaded kernel modules before driver restart: %w", err)
+	}
+
+	module, found := loadedModules[modulePeerMem]
+	if !found {
+		log.V(1).Info("nvidia_peermem module is not loaded")
+		return nil
+	}
+	if module.RefCount > 0 {
+		return fmt.Errorf("nvidia_peermem module is used by other modules: %v", module.UsedBy)
+	}
+	if err := d.host.RmMod(ctx, modulePeerMem); err != nil {
+		return fmt.Errorf("failed to unload nvidia_peermem module: %w", err)
+	}
+	log.V(1).Info("nvidia_peermem module unloaded")
 
 	return nil
 }

--- a/entrypoint/internal/driver/driver_test.go
+++ b/entrypoint/internal/driver/driver_test.go
@@ -1912,9 +1912,10 @@ var _ = Describe("Driver", func() {
 
 			// Mock checkLoadedKmodSrcverVsModinfo to return true (modules match)
 			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{
-				"mlx5_core": {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
-				"mlx5_ib":   {Name: "mlx5_ib", RefCount: 1, UsedBy: []string{}},
-				"ib_core":   {Name: "ib_core", RefCount: 1, UsedBy: []string{}},
+				"mlx5_core":   {Name: "mlx5_core", RefCount: 1, UsedBy: []string{}},
+				"mlx5_ib":     {Name: "mlx5_ib", RefCount: 1, UsedBy: []string{}},
+				"ib_core":     {Name: "ib_core", RefCount: 1, UsedBy: []string{}},
+				modulePeerMem: {Name: modulePeerMem, RefCount: 0, UsedBy: []string{}},
 			}, nil)
 
 			// Mock modinfo calls for each module
@@ -1945,6 +1946,7 @@ var _ = Describe("Driver", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeTrue())
 			Expect(dm.newDriverLoaded).To(BeFalse())
+			hostMock.AssertNotCalled(GinkgoT(), "RmMod", mock.Anything, modulePeerMem)
 		})
 
 		It("should setup DKMS when UseDKMS is enabled and modules match", func() {
@@ -2177,6 +2179,7 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{}, nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
 
 			// Mock printLoadedDriverVersion
@@ -2236,6 +2239,7 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{}, nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
 
 			// Mock loadNfsRdma
@@ -2305,6 +2309,7 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{}, nil)
 			expectedError := errors.New("openibd restart failed")
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", expectedError)
 
@@ -2349,6 +2354,7 @@ var _ = Describe("Driver", func() {
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
+			hostMock.EXPECT().LsMod(ctx).Return(map[string]host.LoadedModule{}, nil)
 			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
 
 			// Mock loadNfsRdma failure (should not cause Load to fail)
@@ -2502,8 +2508,18 @@ var _ = Describe("Driver", func() {
 	})
 
 	Context("restartDriver", func() {
+		var (
+			loadedModulesBeforeRestart map[string]host.LoadedModule
+			lsModErr                   error
+		)
+
 		BeforeEach(func() {
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+			loadedModulesBeforeRestart = map[string]host.LoadedModule{}
+			lsModErr = nil
+			hostMock.EXPECT().LsMod(ctx).RunAndReturn(func(context.Context) (map[string]host.LoadedModule, error) {
+				return loadedModulesBeforeRestart, lsModErr
+			}).Once()
 		})
 
 		It("should restart driver successfully", func() {
@@ -2570,14 +2586,25 @@ var _ = Describe("Driver", func() {
 		It("should load mlx5_vdpa when available", func() {
 			cfg.Mlx5AuxiliaryModules = []string{"mlx5_vdpa"}
 			dm = New(constants.DriverContainerModeSources, cfg, cmdMock, hostMock, osMock).(*driverMgr)
+			loadedModulesBeforeRestart = map[string]host.LoadedModule{
+				modulePeerMem: {Name: modulePeerMem, RefCount: 0, UsedBy: []string{}},
+			}
+			var reloadSequence []string
 
 			// Mock loadHostDependencies
 			osMock.EXPECT().ReadFile("/proc/modules").Return([]byte("mlx5_ib 12345 0 - Live 0xffff"), nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "-F", "depends", "mlx5_ib").Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "uname", "-m").Return("x86_64", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-d", "/host", "pci-hyperv-intf").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_vdpa").Return("", "", nil)
-			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Return("", "", nil)
+			cmdMock.EXPECT().RunCommand(ctx, "modprobe", "-r", "mlx5_vdpa").Run(func(context.Context, string, ...string) {
+				reloadSequence = append(reloadSequence, "auxiliary")
+			}).Return("", "", nil)
+			hostMock.EXPECT().RmMod(ctx, modulePeerMem).Run(func(context.Context, string) {
+				reloadSequence = append(reloadSequence, "peermem")
+			}).Return(nil)
+			cmdMock.EXPECT().RunCommand(ctx, "/etc/init.d/openibd", "restart").Run(func(context.Context, string, ...string) {
+				reloadSequence = append(reloadSequence, "openibd")
+			}).Return("", "", nil)
 			cmdMock.EXPECT().RunCommand(ctx, "modinfo", "mlx5_vdpa").Return("", "", nil) // Module exists
 			// Mock GetOSType for non-SLES case
 			hostMock.EXPECT().GetOSType(ctx).Return(constants.OSTypeUbuntu, nil)
@@ -2585,6 +2612,7 @@ var _ = Describe("Driver", func() {
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(reloadSequence).To(Equal([]string{"auxiliary", "peermem", "openibd"}))
 		})
 
 		It("should load mlx5_vdpa with --allow-unsupported on SLES", func() {
@@ -2711,6 +2739,47 @@ var _ = Describe("Driver", func() {
 
 			err := dm.restartDriver(ctx)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should continue when nvidia_peermem is not loaded", func() {
+			Expect(dm.unloadNvidiaPeermem(ctx)).To(Succeed())
+			hostMock.AssertNotCalled(GinkgoT(), "RmMod", mock.Anything, modulePeerMem)
+		})
+
+		It("should unload an unused nvidia_peermem module", func() {
+			loadedModulesBeforeRestart = map[string]host.LoadedModule{
+				modulePeerMem: {Name: modulePeerMem, RefCount: 0, UsedBy: []string{}},
+			}
+			hostMock.EXPECT().RmMod(ctx, modulePeerMem).Return(nil)
+
+			Expect(dm.unloadNvidiaPeermem(ctx)).To(Succeed())
+		})
+
+		It("should fail when nvidia_peermem is in use", func() {
+			loadedModulesBeforeRestart = map[string]host.LoadedModule{
+				modulePeerMem: {Name: modulePeerMem, RefCount: 1, UsedBy: []string{"consumer"}},
+			}
+
+			err := dm.unloadNvidiaPeermem(ctx)
+			Expect(err).To(MatchError("nvidia_peermem module is used by other modules: [consumer]"))
+			hostMock.AssertNotCalled(GinkgoT(), "RmMod", mock.Anything, modulePeerMem)
+		})
+
+		It("should fail when loaded modules cannot be listed", func() {
+			lsModErr = errors.New("lsmod failed")
+
+			err := dm.unloadNvidiaPeermem(ctx)
+			Expect(err).To(MatchError("failed to list loaded kernel modules before driver restart: lsmod failed"))
+		})
+
+		It("should fail when nvidia_peermem cannot be unloaded", func() {
+			loadedModulesBeforeRestart = map[string]host.LoadedModule{
+				modulePeerMem: {Name: modulePeerMem, RefCount: 0, UsedBy: []string{}},
+			}
+			hostMock.EXPECT().RmMod(ctx, modulePeerMem).Return(errors.New("rmmod failed"))
+
+			err := dm.unloadNvidiaPeermem(ctx)
+			Expect(err).To(MatchError("failed to unload nvidia_peermem module: rmmod failed"))
 		})
 	})
 

--- a/entrypoint/internal/entrypoint/entrypoint.go
+++ b/entrypoint/internal/entrypoint/entrypoint.go
@@ -273,8 +273,7 @@ func (e *entrypoint) createUDEVRulesIfRequired(ctx context.Context) error {
 	return nil
 }
 
-// handleKernelModules function ensures the nvidia_peermem module is unloaded
-// and confirms storage and third-party RDMA modules will unload during openibd restart.
+// handleKernelModules confirms storage and third-party RDMA modules will unload during openibd restart.
 func (e *entrypoint) handleKernelModules(ctx context.Context) error {
 	e.log.Info("Verifying loaded modules will not prevent future driver restart")
 
@@ -282,21 +281,6 @@ func (e *entrypoint) handleKernelModules(ctx context.Context) error {
 	if err != nil {
 		e.log.Error(err, "failed to list loaded kernel modules")
 		return err
-	}
-	nvPeerMemInfo, found := loadedModules["nvidia_peermem"]
-	if found {
-		if nvPeerMemInfo.RefCount > 0 {
-			err := fmt.Errorf("module is used by other modules: %s", nvPeerMemInfo.UsedBy)
-			e.log.Error(err, "failed to unload nvidia_peermem module")
-			return err
-		}
-		if err := e.host.RmMod(ctx, "nvidia_peermem"); err != nil {
-			e.log.Error(err, "failed to unload nvidia_peermem module")
-			return err
-		}
-		e.log.V(1).Info("nvidia_peermem module unloaded")
-	} else {
-		e.log.V(1).Info("nvidia_peermem module in not loaded")
 	}
 	if e.config.UnloadStorageModules {
 		// storage modules will be unloaded by the openibd restart, no need to check if they are loaded

--- a/entrypoint/internal/entrypoint/entrypoint_test.go
+++ b/entrypoint/internal/entrypoint/entrypoint_test.go
@@ -17,6 +17,7 @@
 package entrypoint
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"syscall"
@@ -33,6 +34,7 @@ import (
 	driverMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/driver/mocks"
 	netconfigMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/netconfig/mocks"
 	cmdMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/cmd/mocks"
+	"github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/host"
 	hostMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/host/mocks"
 	readyMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/ready/mocks"
 	udevMockPkg "github.com/Mellanox/doca-driver-build/entrypoint/internal/utils/udev/mocks"
@@ -153,6 +155,17 @@ var _ = Describe("Entrypoint", func() {
 			driverMock.On("Unload", mock.Anything).Return(false, fmt.Errorf("test")).Once()
 
 			Expect(e.run(signalCH)).To(HaveOccurred())
+		})
+
+		It("defers nvidia_peermem unloading to the driver restart", func() {
+			e.config.UnloadStorageModules = true
+			e.config.UnloadThirdPartyRdmaModules = true
+			hostMock.On("LsMod", mock.Anything).Return(map[string]host.LoadedModule{
+				"nvidia_peermem": {Name: "nvidia_peermem", RefCount: 0, UsedBy: []string{}},
+			}, nil).Once()
+
+			Expect(e.handleKernelModules(context.Background())).To(Succeed())
+			hostMock.AssertNotCalled(GinkgoT(), "RmMod", mock.Anything, "nvidia_peermem")
 		})
 	})
 


### PR DESCRIPTION
## Problem

With the Go entrypoint (`USE_NEW_ENTRYPOINT=true`), `handleKernelModules` unloaded `nvidia_peermem` during `preStart`, before the source build and driver installation. `openibd restart` runs later from `driver.Load`. That code path creates a source-proven window in which `nvidia_peermem` can become loaded again before `openibd` replaces `ib_uverbs` and the rest of the OFED stack.

In the incident, `openibd` found `nvidia_peermem` depending on `ib_uverbs` and could not complete the reload. The available logs do not prove which actor reloaded the module. GPU Operator's `nvidia-peermem-ctr` is compatible with this race when it manages peer memory against Network Operator-provided MOFED (`USE_HOST_MOFED=false`): it explicitly modprobes from the GPU driver root, so the MOFED container's host blacklist does not by itself block that operation, and an already in-flight readiness check can overlap the reload.

## Fix

- Remove the early `nvidia_peermem` unload from the Go entrypoint pre-start checks.
- Re-run the same loaded/refcount/unload safety logic immediately before `openibd restart`, after storage, third-party RDMA, and mlx5 auxiliary unload preparation.
- Abort before `openibd` if loaded modules cannot be inspected, `nvidia_peermem` has users, or its unload fails.
- Move the existing legacy Bash `unload_blocking_modules` call to the equivalent restart boundary.
- Preserve the matching-driver fast path: if no driver restart is needed, `nvidia_peermem` is not touched.

This deliberately does not classify `nvidia_peermem` as an mlx5 auxiliary or third-party RDMA module, add blacklist/install overrides, add configuration, reload the GPU-owned module from the MOFED container, or retry `openibd`.

## Scope

The cross-operator coordination described here is the supported `USE_HOST_MOFED=false` integration, where GPU Operator consumes Network Operator-managed MOFED. The `USE_HOST_MOFED=true` behavior is outside this fix and has not been validated by this change.

## Why QA did not catch it

Reproduction requires the driver reload plus a module load in the interval between the old early unload and `openibd restart`. With strict init-container preflight checks, an already-loaded blocking module stops before the main container; the reported path continued only after preflight was bypassed. The remaining failure therefore depends on timing and configuration across the Network Operator and GPU Operator rather than on IB hardware alone. QA systems without that overlap, without a peer-memory reload during the window, or using the matching-driver fast path do not reproduce it.

## Validation

- `go test ./... -count=1` in Linux/amd64: pass
- `go build ./...` in Linux/amd64: pass
- `golangci-lint v2.12.2 run` in Linux/amd64: 0 issues
- `go test ./internal/driver -count=1`: pass
- `bash -n entrypoint.sh`: pass
- verified Bash ordering: mlx5 auxiliary unload -> `nvidia_peermem` unload -> `openibd restart`
- `git diff --check`: pass
