### PR TITLE
fix: ignore USE_DKMS when it conflicts with a precompiled image

### DIFF
--- a/RHEL_Dockerfile
+++ b/RHEL_Dockerfile
@@ -167,8 +167,14 @@ ARG D_BUILD_EXTRA_ARGS
 # Build driver - conditionally enable DKMS (same pattern as Ubuntu_Dockerfile)
 # When D_ENABLE_DKMS=true, install.pl creates DKMS-enabled RPMs (source in /usr/src/, dkms.conf)
 # When D_ENABLE_DKMS=false, install.pl creates static kernel modules (--without-dkms)
+# Only the exact string "true" enables DKMS; reject other values so they cannot produce
+# non-DKMS packages while the runtime bool parser treats them as enabled.
 # Build toolchain (gcc, make, autoconf, rpm-build, dkms) is inherited from driver-src.
 RUN set -x && \
+    case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac && \
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         ${OFED_SRC_LOCAL_DIR}/install.pl --without-depcheck --distro ${D_OS} --kernel ${D_KERNEL_VER} --kernel-sources /lib/modules/${D_KERNEL_VER}/build --kernel-only --build-only --without-iser --without-srp --without-isert --without-knem --without-xpmem --without-xpmem-modules --without-xpmem-dkms --with-mlnx-tools --with-ofed-scripts --copy-ifnames-udev ${D_BUILD_EXTRA_ARGS}; \
     else \
@@ -194,6 +200,13 @@ ARG D_ENABLE_DKMS
 ENV NVIDIA_NIC_DRIVER_VER=${D_OFED_VERSION}
 ENV NVIDIA_NIC_DRIVER_PATH=""
 ENV NVIDIA_NIC_CONTAINER_VER=${D_CONTAINER_VER}
+# Canonical true/false matching install.pl ([ "$D_ENABLE_DKMS" = "true" ]).
+# Reject TRUE/1/yes so Go cannot parse them as enabled against non-DKMS packages.
+RUN case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac
+ENV NVIDIA_NIC_DRIVER_DKMS_ENABLED=${D_ENABLE_DKMS}
 
 COPY --from=driver-builder ${OFED_SRC_LOCAL_DIR}/RPMS/redhat-release-*/${D_ARCH}/*.rpm /root/
 

--- a/SLES_Dockerfile
+++ b/SLES_Dockerfile
@@ -151,7 +151,13 @@ RUN ls -l /lib/modules
 # Build driver --distro ${D_OS}
 # When D_ENABLE_DKMS=true, install.pl creates DKMS-enabled RPMs (source in /usr/src/, dkms.conf)
 # When D_ENABLE_DKMS=false, install.pl creates static kernel modules (--without-dkms)
+# Only the exact string "true" enables DKMS; reject other values so they cannot produce
+# non-DKMS packages while the runtime bool parser treats them as enabled.
 RUN set -x && \
+    case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac && \
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         ${OFED_SRC_LOCAL_DIR}/install.pl -vvv --distro ${D_OS} --kernel-sources /lib/modules/${D_KERNEL_VER}/build --without-depcheck --kernel ${D_KERNEL_VER} --kernel-only --build-only --copy-ifnames-udev --with-mlnx-tools --without-knem-modules --without-srp-modules --without-kernel-mft-modules --without-iser-modules --without-isert-modules --without-xpmem --without-xpmem-modules --without-xpmem-dkms; \
     else \
@@ -175,6 +181,13 @@ ARG D_ENABLE_DKMS
 ENV NVIDIA_NIC_DRIVER_VER=${D_OFED_VERSION}
 ENV NVIDIA_NIC_DRIVER_PATH=""
 ENV NVIDIA_NIC_CONTAINER_VER=${D_CONTAINER_VER}
+# Canonical true/false matching install.pl ([ "$D_ENABLE_DKMS" = "true" ]).
+# Reject TRUE/1/yes so Go cannot parse them as enabled against non-DKMS packages.
+RUN case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac
+ENV NVIDIA_NIC_DRIVER_DKMS_ENABLED=${D_ENABLE_DKMS}
 
 ENV NVIDIA_NIC_DRIVER_PATH=""
 COPY --from=driver-builder ${OFED_SRC_LOCAL_DIR}/RPMS/sles-release-*/${D_ARCH}/*.rpm /root/

--- a/Ubuntu_Dockerfile
+++ b/Ubuntu_Dockerfile
@@ -151,7 +151,13 @@ RUN set -x && \
 
 # Build driver. When D_ENABLE_DKMS=true, install.pl produces DKMS-enabled .deb packages
 # (source + dkms.conf under /usr/src/<module>-<version>/). When false, --without-dkms is used.
+# Only the exact string "true" enables DKMS; reject other values so they cannot produce
+# non-DKMS packages while the runtime bool parser treats them as enabled.
 RUN set -x && \
+    case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac && \
     if [ "$D_ENABLE_DKMS" = "true" ]; then \
         ${OFED_SRC_LOCAL_DIR}/install.pl --without-depcheck --distro ${D_OS} --kernel ${D_KERNEL_VER} --kernel-only --build-only --copy-ifnames-udev --with-mlnx-tools --without-knem-modules --without-srp-modules --without-kernel-mft-modules --without-iser-modules --without-isert-modules ${D_BUILD_EXTRA_ARGS}; \
     else \
@@ -171,6 +177,13 @@ ARG OFED_SRC_LOCAL_DIR
 ARG D_ENABLE_DKMS
 
 ENV NVIDIA_NIC_DRIVER_PATH=""
+# Canonical true/false matching install.pl ([ "$D_ENABLE_DKMS" = "true" ]).
+# Reject TRUE/1/yes so Go cannot parse them as enabled against non-DKMS packages.
+RUN case "$D_ENABLE_DKMS" in \
+        true|false) ;; \
+        *) echo "error: D_ENABLE_DKMS must be exactly 'true' or 'false', got '$D_ENABLE_DKMS'" >&2; exit 1 ;; \
+    esac
+ENV NVIDIA_NIC_DRIVER_DKMS_ENABLED=${D_ENABLE_DKMS}
 
 RUN set -x && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" lsb-release && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,9 @@ THIRD_PARTY_RDMA_MODULES="${THIRD_PARTY_RDMA_MODULES:-bnxt_re efa erdma iw_cxgb4
 
 : ${UBUNTU_PRO_TOKEN:=""}
 
+# Recorded before defaulting so a precompiled image overriding USE_DKMS can tell an
+# explicit user request apart from the default.
+[[ -n "${USE_DKMS+x}" ]] && use_dkms_requested=true || use_dkms_requested=false
 : ${USE_DKMS:=false}
 DKMS_MODULE_NAME=""
 DKMS_MODULE_VERSION=""
@@ -1957,6 +1960,16 @@ if [ -z "${NVIDIA_NIC_DRIVER_VER}" ]; then
 fi
 
 timestamp_print "Container full version: ${NVIDIA_NIC_DRIVER_VER}-${NVIDIA_NIC_CONTAINER_VER}"
+
+# The DKMS layout of a precompiled image is fixed at build time, so the value baked in by
+# the image build takes precedence over a user-supplied USE_DKMS. The variable is absent in
+# sources images and in precompiled images built before it existed.
+if [[ -n "${NVIDIA_NIC_DRIVER_DKMS_ENABLED}" ]] && [[ "${NVIDIA_NIC_DRIVER_DKMS_ENABLED}" != "${USE_DKMS}" ]]; then
+    if ${use_dkms_requested}; then
+        timestamp_print "USE_DKMS=${USE_DKMS} ignored, precompiled image was built with DKMS=${NVIDIA_NIC_DRIVER_DKMS_ENABLED}"
+    fi
+    USE_DKMS="${NVIDIA_NIC_DRIVER_DKMS_ENABLED}"
+fi
 
 unload_blocking_modules
 

--- a/entrypoint/cmd/main.go
+++ b/entrypoint/cmd/main.go
@@ -79,6 +79,11 @@ func main() {
 
 	log.Info(fmt.Sprintf("Container full version: %s-%s", cfg.NvidiaNicDriverVer, cfg.NvidiaNicContainerVer))
 
+	if cfg.DKMSModeOverridden {
+		log.Info("USE_DKMS was ignored: this precompiled image was built with a fixed DKMS mode",
+			"requested", !cfg.UseDKMS, "effective", cfg.UseDKMS)
+	}
+
 	if log.V(1).Enabled() {
 		//nolint:errchkjson
 		data, _ := json.MarshalIndent(cfg, "", "  ")

--- a/entrypoint/internal/config/config.go
+++ b/entrypoint/internal/config/config.go
@@ -63,6 +63,12 @@ type Config struct {
 
 	// DKMS settings
 	UseDKMS bool `env:"USE_DKMS" envDefault:"false"`
+	// ImageDKMSEnabled is baked into precompiled images from the D_ENABLE_DKMS build arg
+	// and reflects whether the driver packages in the image are DKMS-enabled. It is nil for
+	// sources images and for precompiled images built before this variable existed.
+	ImageDKMSEnabled *bool `env:"NVIDIA_NIC_DRIVER_DKMS_ENABLED"`
+	// DKMSModeOverridden is true when ImageDKMSEnabled overrode a conflicting USE_DKMS.
+	DKMSModeOverridden bool `env:"-"`
 	// UnloadThirdPartyRdmaModules enables blacklisting and unloading of all known
 	// third-party RDMA kernel modules (from rdma-core) before OFED driver reload.
 	// When true, modules from ThirdPartyRDMAModules are:
@@ -97,6 +103,16 @@ func GetConfig() (Config, error) {
 	}
 	if _, configured := os.LookupEnv("MLX5_AUXILIARY_MODULES"); !configured && len(cfg.Mlx5AuxiliaryModules) == 0 {
 		cfg.Mlx5AuxiliaryModules = append(cfg.Mlx5AuxiliaryModules, DefaultMlx5AuxiliaryModules...)
+	}
+	// The DKMS layout of a precompiled image is fixed at build time: enabling DKMS at
+	// runtime on a non-DKMS image has no source tree to build from, and disabling it on a
+	// DKMS image leaves no modules for the running kernel. Either way the container fails,
+	// so the baked value wins and the user's USE_DKMS is ignored.
+	if cfg.ImageDKMSEnabled != nil && *cfg.ImageDKMSEnabled != cfg.UseDKMS {
+		// An unset USE_DKMS just picks up the image value, nothing was overridden.
+		_, requested := os.LookupEnv("USE_DKMS")
+		cfg.UseDKMS = *cfg.ImageDKMSEnabled
+		cfg.DKMSModeOverridden = requested
 	}
 	return cfg, nil
 }

--- a/entrypoint/internal/config/config_test.go
+++ b/entrypoint/internal/config/config_test.go
@@ -35,6 +35,8 @@ var _ = Describe("Config", func() {
 		os.Unsetenv("THIRD_PARTY_RDMA_MODULES")
 		os.Unsetenv("STORAGE_MODULES")
 		os.Unsetenv("MLX5_AUXILIARY_MODULES")
+		os.Unsetenv("USE_DKMS")
+		os.Unsetenv("NVIDIA_NIC_DRIVER_DKMS_ENABLED")
 	})
 
 	Context("UnloadThirdPartyRdmaModules", func() {
@@ -124,6 +126,66 @@ var _ = Describe("Config", func() {
 			cfg, err := GetConfig()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.Mlx5AuxiliaryModules).To(BeEmpty())
+		})
+	})
+
+	Context("UseDKMS", func() {
+		// Sources images, and precompiled images built before NVIDIA_NIC_DRIVER_DKMS_ENABLED
+		// existed, do not declare a baked DKMS mode, so USE_DKMS stays user controlled.
+		It("should honor USE_DKMS when the image declares no DKMS mode", func() {
+			os.Setenv("USE_DKMS", "true")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeTrue())
+			Expect(cfg.ImageDKMSEnabled).To(BeNil())
+			Expect(cfg.DKMSModeOverridden).To(BeFalse())
+		})
+
+		It("should default to false when neither variable is set", func() {
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeFalse())
+			Expect(cfg.DKMSModeOverridden).To(BeFalse())
+		})
+
+		It("should force UseDKMS false when the image was built without DKMS", func() {
+			os.Setenv("NVIDIA_NIC_DRIVER_DKMS_ENABLED", "false")
+			os.Setenv("USE_DKMS", "true")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeFalse())
+			Expect(cfg.DKMSModeOverridden).To(BeTrue())
+		})
+
+		It("should force UseDKMS true when the image was built with DKMS", func() {
+			os.Setenv("NVIDIA_NIC_DRIVER_DKMS_ENABLED", "true")
+			os.Setenv("USE_DKMS", "false")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeTrue())
+			Expect(cfg.DKMSModeOverridden).To(BeTrue())
+		})
+
+		It("should not report an override when both values agree", func() {
+			os.Setenv("NVIDIA_NIC_DRIVER_DKMS_ENABLED", "true")
+			os.Setenv("USE_DKMS", "true")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeTrue())
+			Expect(cfg.DKMSModeOverridden).To(BeFalse())
+		})
+
+		It("should apply the image value without reporting an override when USE_DKMS is unset", func() {
+			os.Setenv("NVIDIA_NIC_DRIVER_DKMS_ENABLED", "true")
+
+			cfg, err := GetConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.UseDKMS).To(BeTrue())
+			Expect(cfg.DKMSModeOverridden).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
Precompiled images bake NVIDIA_NIC_DRIVER_DKMS_ENABLED from D_ENABLE_DKMS. At runtime that value wins over a user-supplied USE_DKMS so DKMS setup is not attempted on images that were built without DKMS packages. fix for redmine bug #5246029.